### PR TITLE
[feat] group 및 invitation 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ out/
 !.env.example
 
 docs/
+docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,15 @@
 services:
   redis:
     image: redis:7.0
+    ports:
+      - '6379:6379'
     networks:
       - mymate-network
 
   app:
-    image: ${DOCKERHUB_USERNAME}/mymate:latest
+    build: .
     env_file:
-      - .env
+      - .env.dev
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379

--- a/src/main/java/com/mymate/mymate/MymateApplication.java
+++ b/src/main/java/com/mymate/mymate/MymateApplication.java
@@ -1,10 +1,19 @@
 package com.mymate.mymate;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import jakarta.annotation.PostConstruct;
+
+@Slf4j
 @SpringBootApplication
 public class MymateApplication {
+
+	@PostConstruct
+	public void logApplicationStart() {
+		log.info("TEST:LOG:::MymateApplication이 로드되었습니다!");
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(MymateApplication.class, args);

--- a/src/main/java/com/mymate/mymate/MymateApplication.java
+++ b/src/main/java/com/mymate/mymate/MymateApplication.java
@@ -3,11 +3,13 @@ package com.mymate.mymate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import jakarta.annotation.PostConstruct;
 
 @Slf4j
 @SpringBootApplication
+@EnableJpaAuditing
 public class MymateApplication {
 
 	@PostConstruct

--- a/src/main/java/com/mymate/mymate/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/auth/service/AuthServiceImpl.java
@@ -22,6 +22,8 @@ import com.mymate.mymate.member.enums.Role;
 import com.mymate.mymate.member.repository.MemberRepository;
 import com.mymate.mymate.term.dto.AgreementRequest;
 import com.mymate.mymate.term.service.AgreementService;
+import com.mymate.mymate.group.service.GroupService;
+import com.mymate.mymate.group.dto.GroupCreateRequest;
 
 @Service
 public class AuthServiceImpl implements AuthService {
@@ -33,8 +35,9 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
     private final AgreementService agreementService;
     private final PhoneVerificationService phoneVerificationService;
+    private final GroupService groupService;
 
-    public AuthServiceImpl(JwtProvider jwtProvider, RefreshTokenStore refreshTokenStore, SocialTokenVerifier socialTokenVerifier, MemberRepository memberRepository, PasswordEncoder passwordEncoder, AgreementService agreementService, PhoneVerificationService phoneVerificationService) {
+    public AuthServiceImpl(JwtProvider jwtProvider, RefreshTokenStore refreshTokenStore, SocialTokenVerifier socialTokenVerifier, MemberRepository memberRepository, PasswordEncoder passwordEncoder, AgreementService agreementService, PhoneVerificationService phoneVerificationService, GroupService groupService) {
         this.jwtProvider = jwtProvider;
         this.refreshTokenStore = refreshTokenStore;
         this.socialTokenVerifier = socialTokenVerifier;
@@ -42,6 +45,7 @@ public class AuthServiceImpl implements AuthService {
         this.passwordEncoder = passwordEncoder;
         this.agreementService = agreementService;
         this.phoneVerificationService = phoneVerificationService;
+        this.groupService = groupService;
     }
 
     @Override
@@ -183,6 +187,10 @@ public class AuthServiceImpl implements AuthService {
                 .verifyLatestVersion(true)
                 .build();
         agreementService.agree(member.getId(), agreementRequest);
+
+        // 기본 그룹 생성
+        GroupCreateRequest groupCreateRequest = new GroupCreateRequest("우리집");
+        groupService.createGroup(groupCreateRequest, member.getId());
 
         // 최종 토큰 발급
         TokenPair tokens = issueTokensOnLogin(member.getId(), member.getEmail(), member.getUsername(), Role.USER, true);

--- a/src/main/java/com/mymate/mymate/common/exception/group/GroupHandler.java
+++ b/src/main/java/com/mymate/mymate/common/exception/group/GroupHandler.java
@@ -1,0 +1,10 @@
+package com.mymate.mymate.common.exception.group;
+
+import com.mymate.mymate.common.exception.general.GeneralException;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+
+public class GroupHandler extends GeneralException {
+    public GroupHandler(GroupErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/mymate/mymate/common/exception/group/status/GroupSuccessStatus.java
+++ b/src/main/java/com/mymate/mymate/common/exception/group/status/GroupSuccessStatus.java
@@ -1,0 +1,40 @@
+package com.mymate.mymate.common.exception.group.status;
+
+import com.mymate.mymate.common.exception.general.status.SuccessResponse;
+import org.springframework.http.HttpStatus;
+
+public enum GroupSuccessStatus implements SuccessResponse {
+
+    // 그룹 관련
+    GROUP_CREATED(HttpStatus.CREATED, "GROUP2000", "그룹이 성공적으로 생성되었습니다."),
+    GROUP_JOINED(HttpStatus.OK, "GROUP2001", "그룹에 성공적으로 참여했습니다."),
+    GROUP_LEFT(HttpStatus.OK, "GROUP2002", "그룹에서 성공적으로 탈퇴했습니다."),
+    GROUP_MEMBER_ADDED(HttpStatus.OK, "GROUP2003", "그룹에 멤버를 성공적으로 추가했습니다."),
+    GROUP_MEMBER_REMOVED(HttpStatus.OK, "GROUP2004", "그룹에서 멤버를 성공적으로 제거했습니다."),
+    GROUP_LIST_FETCHED(HttpStatus.OK, "GROUP2005", "그룹 목록을 성공적으로 조회했습니다."),
+    
+    // 초대 관련
+    INVITATION_CREATED(HttpStatus.CREATED, "GROUP2010", "초대가 성공적으로 생성되었습니다."),
+    INVITATION_ACCEPTED(HttpStatus.OK, "GROUP2011", "초대를 성공적으로 수락했습니다."),
+    INVITATION_CANCELLED(HttpStatus.OK, "GROUP2012", "초대를 성공적으로 취소했습니다."),
+    INVITATION_LIST_FETCHED(HttpStatus.OK, "GROUP2013", "초대 목록을 성공적으로 조회했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    GroupSuccessStatus(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getSuccessStatus() { return httpStatus; }
+
+    @Override
+    public String getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/src/main/java/com/mymate/mymate/config/RedisConfig.java
+++ b/src/main/java/com/mymate/mymate/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.mymate.mymate.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -8,10 +10,23 @@ import org.springframework.data.redis.core.convert.RedisCustomConversions;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import jakarta.annotation.PostConstruct;
 import java.util.List;
 
+@Slf4j
 @Configuration
 public class RedisConfig {
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    @PostConstruct
+    public void logRedisConfig() {
+        log.info("REDIS:CONFIG:::Redis 연결 설정 - Host: {}, Port: {}", redisHost, redisPort);
+    }
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {

--- a/src/main/java/com/mymate/mymate/group/GroupHandler.java
+++ b/src/main/java/com/mymate/mymate/group/GroupHandler.java
@@ -10,12 +10,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GroupHandler extends ExceptionAdvice {
 
-    @Override
     protected void logException(Exception exception, ErrorStatus errorStatus) {
         log.error("Group 도메인 예외 발생: {}", exception.getMessage(), exception);
     }
 
-    @Override
     protected void logException(Exception exception, GroupErrorStatus errorStatus) {
         log.error("Group 도메인 예외 발생: {}", exception.getMessage(), exception);
     }

--- a/src/main/java/com/mymate/mymate/group/GroupHandler.java
+++ b/src/main/java/com/mymate/mymate/group/GroupHandler.java
@@ -1,0 +1,22 @@
+package com.mymate.mymate.group;
+
+import com.mymate.mymate.common.exception.ExceptionAdvice;
+import com.mymate.mymate.common.exception.general.status.ErrorStatus;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GroupHandler extends ExceptionAdvice {
+
+    @Override
+    protected void logException(Exception exception, ErrorStatus errorStatus) {
+        log.error("Group 도메인 예외 발생: {}", exception.getMessage(), exception);
+    }
+
+    @Override
+    protected void logException(Exception exception, GroupErrorStatus errorStatus) {
+        log.error("Group 도메인 예외 발생: {}", exception.getMessage(), exception);
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/controller/GroupController.java
+++ b/src/main/java/com/mymate/mymate/group/controller/GroupController.java
@@ -1,0 +1,78 @@
+package com.mymate.mymate.group.controller;
+
+import com.mymate.mymate.group.dto.GroupCreateRequest;
+import com.mymate.mymate.group.dto.GroupResponse;
+import com.mymate.mymate.group.service.GroupService;
+import com.mymate.mymate.common.exception.general.status.SuccessResponse;
+import com.mymate.mymate.common.exception.general.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Group", description = "그룹 관리 API")
+public class GroupController {
+
+    private final GroupService groupService;
+
+    @PostMapping
+    @Operation(summary = "그룹 생성", description = "새로운 그룹을 생성합니다.")
+    public ResponseEntity<GroupResponse> createGroup(
+            @Valid @RequestBody GroupCreateRequest request,
+            @AuthenticationPrincipal Long memberId) {
+        
+        GroupResponse response = groupService.createGroup(request, memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 그룹 목록 조회", description = "현재 사용자가 속한 그룹 목록을 조회합니다.")
+    public ResponseEntity<List<GroupResponse>> getMyGroups(
+            @AuthenticationPrincipal Long memberId) {
+        
+        List<GroupResponse> response = groupService.getMyGroups(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{groupId}/leave")
+    @Operation(summary = "그룹 탈퇴", description = "현재 사용자가 그룹에서 탈퇴합니다.")
+    public ResponseEntity<SuccessResponse> leaveGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal Long memberId) {
+        
+        groupService.leaveGroup(groupId, memberId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "그룹에서 탈퇴했습니다."));
+    }
+
+    @PostMapping("/{groupId}/members")
+    @Operation(summary = "그룹 멤버 직접 추가", description = "그룹에 멤버를 직접 추가합니다.")
+    public ResponseEntity<SuccessResponse> addMember(
+            @PathVariable Long groupId,
+            @RequestParam Long memberId,
+            @AuthenticationPrincipal Long requesterId) {
+        
+        groupService.addMember(groupId, memberId, requesterId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "그룹에 멤버를 추가했습니다."));
+    }
+
+    @DeleteMapping("/{groupId}/members/{memberId}")
+    @Operation(summary = "그룹 멤버 제거", description = "그룹에서 멤버를 제거합니다.")
+    public ResponseEntity<SuccessResponse> removeMember(
+            @PathVariable Long groupId,
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal Long requesterId) {
+        
+        groupService.removeMember(groupId, memberId, requesterId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "그룹에서 멤버를 제거했습니다."));
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/controller/InvitationController.java
+++ b/src/main/java/com/mymate/mymate/group/controller/InvitationController.java
@@ -1,0 +1,67 @@
+package com.mymate.mymate.group.controller;
+
+import com.mymate.mymate.group.dto.InvitationCreateRequest;
+import com.mymate.mymate.group.dto.InvitationResponse;
+import com.mymate.mymate.group.service.InvitationService;
+import com.mymate.mymate.common.exception.general.status.SuccessResponse;
+import com.mymate.mymate.common.exception.general.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/invitations")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Invitation", description = "초대 관리 API")
+public class InvitationController {
+
+    private final InvitationService invitationService;
+
+    @PostMapping("/groups/{groupId}/invitations")
+    @Operation(summary = "그룹 초대 생성", description = "특정 그룹에 사용자를 초대합니다.")
+    public ResponseEntity<InvitationResponse> createInvitation(
+            @PathVariable Long groupId,
+            @Valid @RequestBody InvitationCreateRequest request,
+            @AuthenticationPrincipal Long inviterId) {
+        
+        InvitationResponse response = invitationService.createInvitation(request, groupId, inviterId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 초대 목록 조회", description = "현재 사용자에게 온 초대 목록을 조회합니다.")
+    public ResponseEntity<List<InvitationResponse>> getMyInvitations(
+            @AuthenticationPrincipal Long memberId) {
+        
+        List<InvitationResponse> response = invitationService.getMyInvitations(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{invitationId}/accept")
+    @Operation(summary = "초대 수락", description = "받은 초대를 수락합니다.")
+    public ResponseEntity<SuccessResponse> acceptInvitation(
+            @PathVariable Long invitationId,
+            @AuthenticationPrincipal Long memberId) {
+        
+        invitationService.acceptInvitation(invitationId, memberId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "초대를 수락했습니다."));
+    }
+
+    @PostMapping("/{invitationId}/cancel")
+    @Operation(summary = "초대 취소", description = "초대를 취소합니다.")
+    public ResponseEntity<SuccessResponse> cancelInvitation(
+            @PathVariable Long invitationId,
+            @AuthenticationPrincipal Long memberId) {
+        
+        invitationService.cancelInvitation(invitationId, memberId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "초대를 취소했습니다."));
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/dto/GroupCreateRequest.java
+++ b/src/main/java/com/mymate/mymate/group/dto/GroupCreateRequest.java
@@ -1,0 +1,19 @@
+package com.mymate.mymate.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupCreateRequest {
+
+    @NotBlank(message = "그룹명은 필수입니다")
+    @Size(max = 50, message = "그룹명은 50자를 초과할 수 없습니다")
+    private String name;
+
+    public GroupCreateRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/dto/GroupResponse.java
+++ b/src/main/java/com/mymate/mymate/group/dto/GroupResponse.java
@@ -1,0 +1,43 @@
+package com.mymate.mymate.group.dto;
+
+import com.mymate.mymate.group.entity.Group;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GroupResponse {
+
+    private Long id;
+    private String name;
+    private Long ownerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<MemberResponse> members;
+
+    public GroupResponse(Group group, List<MemberResponse> members) {
+        this.id = group.getId();
+        this.name = group.getName();
+        this.ownerId = group.getOwnerId();
+        this.createdAt = group.getCreatedAt();
+        this.updatedAt = group.getUpdatedAt();
+        this.members = members;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class MemberResponse {
+        private Long id;
+        private Long memberId;
+        private LocalDateTime joinedAt;
+
+        public MemberResponse(Long id, Long memberId, LocalDateTime joinedAt) {
+            this.id = id;
+            this.memberId = memberId;
+            this.joinedAt = joinedAt;
+        }
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/dto/GroupUpdateNameRequest.java
+++ b/src/main/java/com/mymate/mymate/group/dto/GroupUpdateNameRequest.java
@@ -1,0 +1,19 @@
+package com.mymate.mymate.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupUpdateNameRequest {
+
+    @NotBlank(message = "그룹명은 필수입니다")
+    @Size(max = 50, message = "그룹명은 50자를 초과할 수 없습니다")
+    private String name;
+
+    public GroupUpdateNameRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/dto/InvitationCreateRequest.java
+++ b/src/main/java/com/mymate/mymate/group/dto/InvitationCreateRequest.java
@@ -1,0 +1,17 @@
+package com.mymate.mymate.group.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InvitationCreateRequest {
+
+    @NotNull(message = "초대받을 사용자 ID는 필수입니다")
+    private Long inviteeId;
+
+    public InvitationCreateRequest(Long inviteeId) {
+        this.inviteeId = inviteeId;
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/dto/InvitationCreateRequest.java
+++ b/src/main/java/com/mymate/mymate/group/dto/InvitationCreateRequest.java
@@ -1,17 +1,20 @@
 package com.mymate.mymate.group.dto;
 
-import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "그룹 초대 생성 요청")
 public class InvitationCreateRequest {
 
-    @NotNull(message = "초대받을 사용자 ID는 필수입니다")
-    private Long inviteeId;
+    @NotBlank(message = "초대받을 사용자 식별자는 필수입니다")
+    @Schema(description = "초대받을 사용자 식별자 (사용자 ID 또는 이메일)", example = "SZZYDE770", required = true)
+    private String inviteeIdentifier;  // 사용자 ID 또는 이메일 (예: "SZZYDE770" 또는 "user@gmail.com")
 
-    public InvitationCreateRequest(Long inviteeId) {
-        this.inviteeId = inviteeId;
+    public InvitationCreateRequest(String inviteeIdentifier) {
+        this.inviteeIdentifier = inviteeIdentifier;
     }
 }

--- a/src/main/java/com/mymate/mymate/group/dto/InvitationResponse.java
+++ b/src/main/java/com/mymate/mymate/group/dto/InvitationResponse.java
@@ -1,0 +1,34 @@
+package com.mymate.mymate.group.dto;
+
+import com.mymate.mymate.group.entity.Invitation;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class InvitationResponse {
+
+    private Long id;
+    private Long groupId;
+    private String groupName;
+    private Long inviterId;
+    private String inviterName;
+    private Long inviteeId;
+    private LocalDateTime expiresAt;
+    private Invitation.InvitationStatus status;
+    private LocalDateTime createdAt;
+
+    public InvitationResponse(Invitation invitation, String groupName, String inviterName) {
+        this.id = invitation.getId();
+        this.groupId = invitation.getGroupId();
+        this.groupName = groupName;
+        this.inviterId = invitation.getInviterId();
+        this.inviterName = inviterName;
+        this.inviteeId = invitation.getInviteeId();
+        this.expiresAt = invitation.getExpiresAt();
+        this.status = invitation.getStatus();
+        this.createdAt = invitation.getCreatedAt();
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/entity/Group.java
+++ b/src/main/java/com/mymate/mymate/group/entity/Group.java
@@ -1,0 +1,35 @@
+package com.mymate.mymate.group.entity;
+
+import com.mymate.mymate.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "groups")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Group extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "owner_id", nullable = false)
+    private Long ownerId;
+
+    @Builder
+    public Group(String name, Long ownerId) {
+        this.name = name;
+        this.ownerId = ownerId;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/entity/GroupMember.java
+++ b/src/main/java/com/mymate/mymate/group/entity/GroupMember.java
@@ -1,0 +1,37 @@
+package com.mymate.mymate.group.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "group_members", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"group_id", "member_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Builder
+    public GroupMember(Long groupId, Long memberId) {
+        this.groupId = groupId;
+        this.memberId = memberId;
+        this.joinedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/entity/Invitation.java
+++ b/src/main/java/com/mymate/mymate/group/entity/Invitation.java
@@ -1,0 +1,70 @@
+package com.mymate.mymate.group.entity;
+
+import com.mymate.mymate.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "invitations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Invitation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(name = "inviter_id", nullable = false)
+    private Long inviterId;
+
+    @Column(name = "invitee_id", nullable = false)
+    private Long inviteeId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InvitationStatus status;
+
+    @Builder
+    public Invitation(Long groupId, Long inviterId, Long inviteeId, LocalDateTime expiresAt) {
+        this.groupId = groupId;
+        this.inviterId = inviterId;
+        this.inviteeId = inviteeId;
+        this.expiresAt = expiresAt;
+        this.status = InvitationStatus.PENDING;
+    }
+
+    public void accept() {
+        this.status = InvitationStatus.ACCEPTED;
+    }
+
+    public void cancel() {
+        this.status = InvitationStatus.CANCELED;
+    }
+
+    public void expire() {
+        this.status = InvitationStatus.EXPIRED;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+
+    public boolean isPending() {
+        return this.status == InvitationStatus.PENDING;
+    }
+
+    public enum InvitationStatus {
+        PENDING, ACCEPTED, EXPIRED, CANCELED
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/mymate/mymate/group/repository/GroupMemberRepository.java
@@ -1,0 +1,25 @@
+package com.mymate.mymate.group.repository;
+
+import com.mymate.mymate.group.entity.GroupMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    
+    List<GroupMember> findByMemberId(Long memberId);
+    
+    List<GroupMember> findByGroupId(Long groupId);
+    
+    Optional<GroupMember> findByGroupIdAndMemberId(Long groupId, Long memberId);
+    
+    boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
+    
+    @Query("SELECT gm FROM GroupMember gm WHERE gm.memberId = :memberId")
+    List<GroupMember> findGroupsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/mymate/mymate/group/repository/GroupRepository.java
+++ b/src/main/java/com/mymate/mymate/group/repository/GroupRepository.java
@@ -1,0 +1,13 @@
+package com.mymate.mymate.group.repository;
+
+import com.mymate.mymate.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+    
+    List<Group> findByOwnerId(Long ownerId);
+}

--- a/src/main/java/com/mymate/mymate/group/repository/InvitationRepository.java
+++ b/src/main/java/com/mymate/mymate/group/repository/InvitationRepository.java
@@ -1,0 +1,27 @@
+package com.mymate.mymate.group.repository;
+
+import com.mymate.mymate.group.entity.Invitation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+    
+    List<Invitation> findByInviteeIdAndStatus(Long inviteeId, Invitation.InvitationStatus status);
+    
+    Optional<Invitation> findByGroupIdAndInviteeIdAndStatus(Long groupId, Long inviteeId, Invitation.InvitationStatus status);
+    
+    boolean existsByGroupIdAndInviteeIdAndStatus(Long groupId, Long inviteeId, Invitation.InvitationStatus status);
+    
+    @Query("SELECT i FROM Invitation i WHERE i.expiresAt < :now AND i.status = 'PENDING'")
+    List<Invitation> findExpiredInvitations(@Param("now") LocalDateTime now);
+    
+    @Query("SELECT i FROM Invitation i WHERE i.inviteeId = :inviteeId AND i.status = 'PENDING'")
+    List<Invitation> findPendingInvitationsByInviteeId(@Param("inviteeId") Long inviteeId);
+}

--- a/src/main/java/com/mymate/mymate/group/service/GroupService.java
+++ b/src/main/java/com/mymate/mymate/group/service/GroupService.java
@@ -2,162 +2,18 @@ package com.mymate.mymate.group.service;
 
 import com.mymate.mymate.group.dto.GroupCreateRequest;
 import com.mymate.mymate.group.dto.GroupResponse;
-import com.mymate.mymate.group.entity.Group;
-import com.mymate.mymate.group.entity.GroupMember;
-import com.mymate.mymate.group.repository.GroupMemberRepository;
-import com.mymate.mymate.group.repository.GroupRepository;
-import com.mymate.mymate.member.Member;
-import com.mymate.mymate.member.repository.MemberRepository;
-import com.mymate.mymate.common.exception.general.GeneralException;
-import com.mymate.mymate.common.exception.general.status.ErrorStatus;
-import com.mymate.mymate.group.status.GroupErrorStatus;
-import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-@Transactional(readOnly = true)
-public class GroupService {
-
-    private final GroupRepository groupRepository;
-    private final GroupMemberRepository groupMemberRepository;
-    private final MemberRepository memberRepository;
-
-    @Transactional
-    public GroupResponse createGroup(GroupCreateRequest request, Long ownerId) {
-        // 소유자 정보 확인
-        Member owner = memberRepository.findById(ownerId)
-                .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
-
-        // 기본 그룹명 설정 (요청이 없으면 "우리집")
-        String groupName = request.getName() != null ? request.getName() : "우리집";
-
-        // 그룹 생성
-        Group group = Group.builder()
-                .name(groupName)
-                .ownerId(ownerId)
-                .build();
-        
-        Group savedGroup = groupRepository.save(group);
-
-        // 소유자를 그룹 멤버로 추가
-        GroupMember ownerMember = GroupMember.builder()
-                .groupId(savedGroup.getId())
-                .memberId(ownerId)
-                .build();
-        
-        groupMemberRepository.save(ownerMember);
-
-        log.info("그룹 생성 완료: groupId={}, ownerId={}, name={}", savedGroup.getId(), ownerId, groupName);
-
-        return new GroupResponse(savedGroup, List.of());
-    }
-
-    public List<GroupResponse> getMyGroups(Long memberId) {
-        // 멤버가 속한 그룹들 조회
-        List<GroupMember> groupMembers = groupMemberRepository.findByMemberId(memberId);
-        
-        return groupMembers.stream()
-                .map(groupMember -> {
-                    Group group = groupRepository.findById(groupMember.getGroupId())
-                            .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
-                    
-                    // 그룹의 모든 멤버 조회
-                    List<GroupMember> allMembers = groupMemberRepository.findByGroupId(group.getId());
-                    List<GroupResponse.MemberResponse> memberResponses = allMembers.stream()
-                            .map(member -> new GroupResponse.MemberResponse(
-                                    member.getId(), 
-                                    member.getMemberId(), 
-                                    member.getJoinedAt()))
-                            .collect(Collectors.toList());
-                    
-                    return new GroupResponse(group, memberResponses);
-                })
-                .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void leaveGroup(Long groupId, Long memberId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
-
-        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.MEMBER_NOT_IN_GROUP));
-
-        // 소유자가 마지막 멤버인 경우 그룹 삭제
-        if (group.getOwnerId().equals(memberId)) {
-            List<GroupMember> remainingMembers = groupMemberRepository.findByGroupId(groupId);
-            if (remainingMembers.size() == 1) {
-                groupRepository.delete(group);
-                log.info("그룹 삭제됨 (소유자 탈퇴): groupId={}", groupId);
-                return;
-            }
-        }
-
-        // 그룹 멤버에서 제거
-        groupMemberRepository.delete(groupMember);
-        log.info("그룹 탈퇴 완료: groupId={}, memberId={}", groupId, memberId);
-    }
-
-    @Transactional
-    public void removeMember(Long groupId, Long memberId, Long requesterId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
-
-        // 소유자만 멤버 제거 가능
-        if (!group.getOwnerId().equals(requesterId)) {
-            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
-        }
-
-        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.MEMBER_NOT_IN_GROUP));
-
-        // 소유자 본인은 제거할 수 없음
-        if (groupMember.getMemberId().equals(group.getOwnerId())) {
-            throw new GeneralException(GroupErrorStatus.CANNOT_REMOVE_OWNER);
-        }
-
-        groupMemberRepository.delete(groupMember);
-        log.info("그룹 멤버 제거 완료: groupId={}, removedMemberId={}, requesterId={}", 
-                groupId, memberId, requesterId);
-    }
-
-    @Transactional
-    public void addMember(Long groupId, Long memberId, Long requesterId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
-
-        // 소유자만 멤버 추가 가능
-        if (!group.getOwnerId().equals(requesterId)) {
-            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
-        }
-
-        // 이미 그룹에 속한 멤버인지 확인
-        if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
-            throw new GeneralException(GroupErrorStatus.MEMBER_ALREADY_IN_GROUP);
-        }
-
-        // 기존 그룹에서 탈퇴 처리 (단일 그룹 정책)
-        List<GroupMember> existingMemberships = groupMemberRepository.findByMemberId(memberId);
-        for (GroupMember existingMembership : existingMemberships) {
-            groupMemberRepository.delete(existingMembership);
-        }
-
-        // 새 그룹에 멤버 추가
-        GroupMember newMember = GroupMember.builder()
-                .groupId(groupId)
-                .memberId(memberId)
-                .build();
-        
-        groupMemberRepository.save(newMember);
-        log.info("그룹 멤버 추가 완료: groupId={}, memberId={}, requesterId={}", 
-                groupId, memberId, requesterId);
-    }
+public interface GroupService {
+    
+    GroupResponse createGroup(GroupCreateRequest request, Long ownerId);
+    
+    List<GroupResponse> getMyGroups(Long memberId);
+    
+    void leaveGroup(Long groupId, Long memberId);
+    
+    void removeMember(Long groupId, Long memberId, Long requesterId);
+    
+    void addMember(Long groupId, Long memberId, Long requesterId);
 }

--- a/src/main/java/com/mymate/mymate/group/service/GroupService.java
+++ b/src/main/java/com/mymate/mymate/group/service/GroupService.java
@@ -2,6 +2,7 @@ package com.mymate.mymate.group.service;
 
 import com.mymate.mymate.group.dto.GroupCreateRequest;
 import com.mymate.mymate.group.dto.GroupResponse;
+import com.mymate.mymate.group.dto.GroupUpdateNameRequest;
 
 import java.util.List;
 
@@ -16,4 +17,6 @@ public interface GroupService {
     void removeMember(Long groupId, Long memberId, Long requesterId);
     
     void addMember(Long groupId, Long memberId, Long requesterId);
+    
+    GroupResponse updateGroupName(Long groupId, GroupUpdateNameRequest request, Long requesterId);
 }

--- a/src/main/java/com/mymate/mymate/group/service/GroupService.java
+++ b/src/main/java/com/mymate/mymate/group/service/GroupService.java
@@ -11,7 +11,7 @@ import com.mymate.mymate.member.repository.MemberRepository;
 import com.mymate.mymate.common.exception.general.GeneralException;
 import com.mymate.mymate.common.exception.general.status.ErrorStatus;
 import com.mymate.mymate.group.status.GroupErrorStatus;
-import com.mymate.mymate.member.status.MemberErrorStatus;
+import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/mymate/mymate/group/service/GroupService.java
+++ b/src/main/java/com/mymate/mymate/group/service/GroupService.java
@@ -1,0 +1,163 @@
+package com.mymate.mymate.group.service;
+
+import com.mymate.mymate.group.dto.GroupCreateRequest;
+import com.mymate.mymate.group.dto.GroupResponse;
+import com.mymate.mymate.group.entity.Group;
+import com.mymate.mymate.group.entity.GroupMember;
+import com.mymate.mymate.group.repository.GroupMemberRepository;
+import com.mymate.mymate.group.repository.GroupRepository;
+import com.mymate.mymate.member.Member;
+import com.mymate.mymate.member.repository.MemberRepository;
+import com.mymate.mymate.common.exception.general.GeneralException;
+import com.mymate.mymate.common.exception.general.status.ErrorStatus;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+import com.mymate.mymate.member.status.MemberErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public GroupResponse createGroup(GroupCreateRequest request, Long ownerId) {
+        // 소유자 정보 확인
+        Member owner = memberRepository.findById(ownerId)
+                .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        // 기본 그룹명 설정 (요청이 없으면 "우리집")
+        String groupName = request.getName() != null ? request.getName() : "우리집";
+
+        // 그룹 생성
+        Group group = Group.builder()
+                .name(groupName)
+                .ownerId(ownerId)
+                .build();
+        
+        Group savedGroup = groupRepository.save(group);
+
+        // 소유자를 그룹 멤버로 추가
+        GroupMember ownerMember = GroupMember.builder()
+                .groupId(savedGroup.getId())
+                .memberId(ownerId)
+                .build();
+        
+        groupMemberRepository.save(ownerMember);
+
+        log.info("그룹 생성 완료: groupId={}, ownerId={}, name={}", savedGroup.getId(), ownerId, groupName);
+
+        return new GroupResponse(savedGroup, List.of());
+    }
+
+    public List<GroupResponse> getMyGroups(Long memberId) {
+        // 멤버가 속한 그룹들 조회
+        List<GroupMember> groupMembers = groupMemberRepository.findByMemberId(memberId);
+        
+        return groupMembers.stream()
+                .map(groupMember -> {
+                    Group group = groupRepository.findById(groupMember.getGroupId())
+                            .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
+                    
+                    // 그룹의 모든 멤버 조회
+                    List<GroupMember> allMembers = groupMemberRepository.findByGroupId(group.getId());
+                    List<GroupResponse.MemberResponse> memberResponses = allMembers.stream()
+                            .map(member -> new GroupResponse.MemberResponse(
+                                    member.getId(), 
+                                    member.getMemberId(), 
+                                    member.getJoinedAt()))
+                            .collect(Collectors.toList());
+                    
+                    return new GroupResponse(group, memberResponses);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void leaveGroup(Long groupId, Long memberId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.MEMBER_NOT_IN_GROUP));
+
+        // 소유자가 마지막 멤버인 경우 그룹 삭제
+        if (group.getOwnerId().equals(memberId)) {
+            List<GroupMember> remainingMembers = groupMemberRepository.findByGroupId(groupId);
+            if (remainingMembers.size() == 1) {
+                groupRepository.delete(group);
+                log.info("그룹 삭제됨 (소유자 탈퇴): groupId={}", groupId);
+                return;
+            }
+        }
+
+        // 그룹 멤버에서 제거
+        groupMemberRepository.delete(groupMember);
+        log.info("그룹 탈퇴 완료: groupId={}, memberId={}", groupId, memberId);
+    }
+
+    @Transactional
+    public void removeMember(Long groupId, Long memberId, Long requesterId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        // 소유자만 멤버 제거 가능
+        if (!group.getOwnerId().equals(requesterId)) {
+            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
+        }
+
+        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.MEMBER_NOT_IN_GROUP));
+
+        // 소유자 본인은 제거할 수 없음
+        if (groupMember.getMemberId().equals(group.getOwnerId())) {
+            throw new GeneralException(GroupErrorStatus.CANNOT_REMOVE_OWNER);
+        }
+
+        groupMemberRepository.delete(groupMember);
+        log.info("그룹 멤버 제거 완료: groupId={}, removedMemberId={}, requesterId={}", 
+                groupId, memberId, requesterId);
+    }
+
+    @Transactional
+    public void addMember(Long groupId, Long memberId, Long requesterId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        // 소유자만 멤버 추가 가능
+        if (!group.getOwnerId().equals(requesterId)) {
+            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 이미 그룹에 속한 멤버인지 확인
+        if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
+            throw new GeneralException(GroupErrorStatus.MEMBER_ALREADY_IN_GROUP);
+        }
+
+        // 기존 그룹에서 탈퇴 처리 (단일 그룹 정책)
+        List<GroupMember> existingMemberships = groupMemberRepository.findByMemberId(memberId);
+        for (GroupMember existingMembership : existingMemberships) {
+            groupMemberRepository.delete(existingMembership);
+        }
+
+        // 새 그룹에 멤버 추가
+        GroupMember newMember = GroupMember.builder()
+                .groupId(groupId)
+                .memberId(memberId)
+                .build();
+        
+        groupMemberRepository.save(newMember);
+        log.info("그룹 멤버 추가 완료: groupId={}, memberId={}, requesterId={}", 
+                groupId, memberId, requesterId);
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/group/service/GroupServiceImpl.java
@@ -1,0 +1,167 @@
+package com.mymate.mymate.group.service;
+
+import com.mymate.mymate.group.dto.GroupCreateRequest;
+import com.mymate.mymate.group.dto.GroupResponse;
+import com.mymate.mymate.group.entity.Group;
+import com.mymate.mymate.group.entity.GroupMember;
+import com.mymate.mymate.group.repository.GroupMemberRepository;
+import com.mymate.mymate.group.repository.GroupRepository;
+import com.mymate.mymate.member.repository.MemberRepository;
+import com.mymate.mymate.common.exception.group.GroupHandler;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+import com.mymate.mymate.common.exception.member.MemberHandler;
+import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GroupServiceImpl implements GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public GroupResponse createGroup(GroupCreateRequest request, Long ownerId) {
+        // 소유자 정보 확인
+        memberRepository.findById(ownerId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        // 기본 그룹명 설정 (요청이 없으면 "우리집")
+        String groupName = request.getName() != null ? request.getName() : "우리집";
+
+        // 그룹 생성
+        Group group = Group.builder()
+                .name(groupName)
+                .ownerId(ownerId)
+                .build();
+        
+        Group savedGroup = groupRepository.save(group);
+
+        // 소유자를 그룹 멤버로 추가
+        GroupMember ownerMember = GroupMember.builder()
+                .groupId(savedGroup.getId())
+                .memberId(ownerId)
+                .build();
+        
+        groupMemberRepository.save(ownerMember);
+
+        log.info("그룹 생성 완료: groupId={}, ownerId={}, name={}", savedGroup.getId(), ownerId, groupName);
+
+        return new GroupResponse(savedGroup, List.of());
+    }
+
+    @Override
+    public List<GroupResponse> getMyGroups(Long memberId) {
+        // 멤버가 속한 그룹들 조회
+        List<GroupMember> groupMembers = groupMemberRepository.findByMemberId(memberId);
+        
+        return groupMembers.stream()
+                .map(groupMember -> {
+                    Group group = groupRepository.findById(groupMember.getGroupId())
+                            .orElseThrow(() -> new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND));
+                    
+                    // 그룹의 모든 멤버 조회
+                    List<GroupMember> allMembers = groupMemberRepository.findByGroupId(group.getId());
+                    List<GroupResponse.MemberResponse> memberResponses = allMembers.stream()
+                            .map(member -> new GroupResponse.MemberResponse(
+                                    member.getId(), 
+                                    member.getMemberId(), 
+                                    member.getJoinedAt()))
+                            .collect(Collectors.toList());
+                    
+                    return new GroupResponse(group, memberResponses);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void leaveGroup(Long groupId, Long memberId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.MEMBER_NOT_IN_GROUP));
+
+        // 소유자가 마지막 멤버인 경우 그룹 삭제
+        if (group.getOwnerId().equals(memberId)) {
+            List<GroupMember> remainingMembers = groupMemberRepository.findByGroupId(groupId);
+            if (remainingMembers.size() == 1) {
+                groupRepository.delete(group);
+                log.info("그룹 삭제됨 (소유자 탈퇴): groupId={}", groupId);
+                return;
+            }
+        }
+
+        // 그룹 멤버에서 제거
+        groupMemberRepository.delete(groupMember);
+        log.info("그룹 탈퇴 완료: groupId={}, memberId={}", groupId, memberId);
+    }
+
+    @Override
+    @Transactional
+    public void removeMember(Long groupId, Long memberId, Long requesterId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        // 소유자만 멤버 제거 가능
+        if (!group.getOwnerId().equals(requesterId)) {
+            throw new GroupHandler(GroupErrorStatus.FORBIDDEN);
+        }
+
+        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.MEMBER_NOT_IN_GROUP));
+
+        // 소유자 본인은 제거할 수 없음
+        if (groupMember.getMemberId().equals(group.getOwnerId())) {
+            throw new GroupHandler(GroupErrorStatus.CANNOT_REMOVE_OWNER);
+        }
+
+        groupMemberRepository.delete(groupMember);
+        log.info("그룹 멤버 제거 완료: groupId={}, removedMemberId={}, requesterId={}", 
+                groupId, memberId, requesterId);
+    }
+
+    @Override
+    @Transactional
+    public void addMember(Long groupId, Long memberId, Long requesterId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        // 소유자만 멤버 추가 가능
+        if (!group.getOwnerId().equals(requesterId)) {
+            throw new GroupHandler(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 이미 그룹에 속한 멤버인지 확인
+        if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
+            throw new GroupHandler(GroupErrorStatus.MEMBER_ALREADY_IN_GROUP);
+        }
+
+        // 기존 그룹에서 탈퇴 처리 (단일 그룹 정책)
+        List<GroupMember> existingMemberships = groupMemberRepository.findByMemberId(memberId);
+        for (GroupMember existingMembership : existingMemberships) {
+            groupMemberRepository.delete(existingMembership);
+        }
+
+        // 새 그룹에 멤버 추가
+        GroupMember newMember = GroupMember.builder()
+                .groupId(groupId)
+                .memberId(memberId)
+                .build();
+        
+        groupMemberRepository.save(newMember);
+        log.info("그룹 멤버 추가 완료: groupId={}, memberId={}, requesterId={}", 
+                groupId, memberId, requesterId);
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/group/service/GroupServiceImpl.java
@@ -2,6 +2,7 @@ package com.mymate.mymate.group.service;
 
 import com.mymate.mymate.group.dto.GroupCreateRequest;
 import com.mymate.mymate.group.dto.GroupResponse;
+import com.mymate.mymate.group.dto.GroupUpdateNameRequest;
 import com.mymate.mymate.group.entity.Group;
 import com.mymate.mymate.group.entity.GroupMember;
 import com.mymate.mymate.group.repository.GroupMemberRepository;
@@ -163,5 +164,35 @@ public class GroupServiceImpl implements GroupService {
         groupMemberRepository.save(newMember);
         log.info("그룹 멤버 추가 완료: groupId={}, memberId={}, requesterId={}", 
                 groupId, memberId, requesterId);
+    }
+
+    @Override
+    @Transactional
+    public GroupResponse updateGroupName(Long groupId, GroupUpdateNameRequest request, Long requesterId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        // 소유자만 그룹 이름 변경 가능
+        if (!group.getOwnerId().equals(requesterId)) {
+            throw new GroupHandler(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 그룹 이름 업데이트
+        group.updateName(request.getName());
+        Group savedGroup = groupRepository.save(group);
+
+        // 그룹의 모든 멤버 조회
+        List<GroupMember> allMembers = groupMemberRepository.findByGroupId(groupId);
+        List<GroupResponse.MemberResponse> memberResponses = allMembers.stream()
+                .map(member -> new GroupResponse.MemberResponse(
+                        member.getId(), 
+                        member.getMemberId(), 
+                        member.getJoinedAt()))
+                .collect(Collectors.toList());
+
+        log.info("그룹 이름 변경 완료: groupId={}, newName={}, requesterId={}", 
+                groupId, request.getName(), requesterId);
+
+        return new GroupResponse(savedGroup, memberResponses);
     }
 }

--- a/src/main/java/com/mymate/mymate/group/service/InvitationService.java
+++ b/src/main/java/com/mymate/mymate/group/service/InvitationService.java
@@ -1,0 +1,171 @@
+package com.mymate.mymate.group.service;
+
+import com.mymate.mymate.group.dto.InvitationCreateRequest;
+import com.mymate.mymate.group.dto.InvitationResponse;
+import com.mymate.mymate.group.entity.Group;
+import com.mymate.mymate.group.entity.GroupMember;
+import com.mymate.mymate.group.entity.Invitation;
+import com.mymate.mymate.group.repository.GroupMemberRepository;
+import com.mymate.mymate.group.repository.GroupRepository;
+import com.mymate.mymate.group.repository.InvitationRepository;
+import com.mymate.mymate.member.Member;
+import com.mymate.mymate.member.repository.MemberRepository;
+import com.mymate.mymate.common.exception.general.GeneralException;
+import com.mymate.mymate.common.exception.general.status.ErrorStatus;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+import com.mymate.mymate.member.status.MemberErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class InvitationService {
+
+    private final InvitationRepository invitationRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+    private final GroupService groupService;
+
+    private static final int INVITATION_EXPIRY_HOURS = 24; // 24시간 후 만료
+
+    @Transactional
+    public InvitationResponse createInvitation(InvitationCreateRequest request, Long groupId, Long inviterId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        // 소유자만 초대 가능
+        if (!group.getOwnerId().equals(inviterId)) {
+            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 초대받을 사용자 존재 확인
+        Member invitee = memberRepository.findById(request.getInviteeId())
+                .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        // 이미 그룹에 속한 멤버인지 확인
+        if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, request.getInviteeId())) {
+            throw new GeneralException(GroupErrorStatus.MEMBER_ALREADY_IN_GROUP);
+        }
+
+        // 이미 대기 중인 초대가 있는지 확인
+        if (invitationRepository.existsByGroupIdAndInviteeIdAndStatus(
+                groupId, request.getInviteeId(), Invitation.InvitationStatus.PENDING)) {
+            throw new GeneralException(GroupErrorStatus.INVITATION_ALREADY_EXISTS);
+        }
+
+        // 초대 생성
+        Invitation invitation = Invitation.builder()
+                .groupId(groupId)
+                .inviterId(inviterId)
+                .inviteeId(request.getInviteeId())
+                .expiresAt(LocalDateTime.now().plusHours(INVITATION_EXPIRY_HOURS))
+                .build();
+
+        Invitation savedInvitation = invitationRepository.save(invitation);
+
+        // 초대자 이름 조회
+        Member inviter = memberRepository.findById(inviterId)
+                .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        log.info("초대 생성 완료: invitationId={}, groupId={}, inviterId={}, inviteeId={}", 
+                savedInvitation.getId(), groupId, inviterId, request.getInviteeId());
+
+        return new InvitationResponse(savedInvitation, group.getName(), inviter.getName());
+    }
+
+    public List<InvitationResponse> getMyInvitations(Long memberId) {
+        List<Invitation> invitations = invitationRepository.findPendingInvitationsByInviteeId(memberId);
+        
+        return invitations.stream()
+                .map(invitation -> {
+                    Group group = groupRepository.findById(invitation.getGroupId())
+                            .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
+                    
+                    Member inviter = memberRepository.findById(invitation.getInviterId())
+                            .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
+                    
+                    return new InvitationResponse(invitation, group.getName(), inviter.getName());
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void acceptInvitation(Long invitationId, Long memberId) {
+        Invitation invitation = invitationRepository.findById(invitationId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.INVITATION_NOT_FOUND));
+
+        // 초대받은 사용자만 수락 가능
+        if (!invitation.getInviteeId().equals(memberId)) {
+            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 이미 처리된 초대인지 확인
+        if (!invitation.isPending()) {
+            throw new GeneralException(GroupErrorStatus.INVITATION_ALREADY_PROCESSED);
+        }
+
+        // 만료된 초대인지 확인
+        if (invitation.isExpired()) {
+            invitation.expire();
+            invitationRepository.save(invitation);
+            throw new GeneralException(GroupErrorStatus.INVITATION_EXPIRED);
+        }
+
+        // 그룹에 멤버 추가 (단일 그룹 정책으로 기존 그룹에서 자동 탈퇴)
+        groupService.addMember(invitation.getGroupId(), memberId, invitation.getInviterId());
+
+        // 초대 상태를 수락으로 변경
+        invitation.accept();
+        invitationRepository.save(invitation);
+
+        log.info("초대 수락 완료: invitationId={}, groupId={}, memberId={}", 
+                invitationId, invitation.getGroupId(), memberId);
+    }
+
+    @Transactional
+    public void cancelInvitation(Long invitationId, Long memberId) {
+        Invitation invitation = invitationRepository.findById(invitationId)
+                .orElseThrow(() -> new GeneralException(GroupErrorStatus.INVITATION_NOT_FOUND));
+
+        // 초대받은 사용자 또는 초대한 사용자만 취소 가능
+        if (!invitation.getInviteeId().equals(memberId) && 
+            !invitation.getInviterId().equals(memberId)) {
+            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 이미 처리된 초대인지 확인
+        if (!invitation.isPending()) {
+            throw new GeneralException(GroupErrorStatus.INVITATION_ALREADY_PROCESSED);
+        }
+
+        invitation.cancel();
+        invitationRepository.save(invitation);
+
+        log.info("초대 취소 완료: invitationId={}, memberId={}", invitationId, memberId);
+    }
+
+    @Scheduled(fixedRate = 3600000) // 1시간마다 실행
+    @Transactional
+    public void expireInvitations() {
+        List<Invitation> expiredInvitations = invitationRepository.findExpiredInvitations(LocalDateTime.now());
+        
+        for (Invitation invitation : expiredInvitations) {
+            invitation.expire();
+            invitationRepository.save(invitation);
+        }
+
+        if (!expiredInvitations.isEmpty()) {
+            log.info("만료된 초대 처리 완료: count={}", expiredInvitations.size());
+        }
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/service/InvitationService.java
+++ b/src/main/java/com/mymate/mymate/group/service/InvitationService.java
@@ -13,7 +13,7 @@ import com.mymate.mymate.member.repository.MemberRepository;
 import com.mymate.mymate.common.exception.general.GeneralException;
 import com.mymate.mymate.common.exception.general.status.ErrorStatus;
 import com.mymate.mymate.group.status.GroupErrorStatus;
-import com.mymate.mymate.member.status.MemberErrorStatus;
+import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -80,7 +80,7 @@ public class InvitationService {
         log.info("초대 생성 완료: invitationId={}, groupId={}, inviterId={}, inviteeId={}", 
                 savedInvitation.getId(), groupId, inviterId, request.getInviteeId());
 
-        return new InvitationResponse(savedInvitation, group.getName(), inviter.getName());
+        return new InvitationResponse(savedInvitation, group.getName(), inviter.getUsername());
     }
 
     public List<InvitationResponse> getMyInvitations(Long memberId) {
@@ -94,7 +94,7 @@ public class InvitationService {
                     Member inviter = memberRepository.findById(invitation.getInviterId())
                             .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
                     
-                    return new InvitationResponse(invitation, group.getName(), inviter.getName());
+                    return new InvitationResponse(invitation, group.getName(), inviter.getUsername());
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/mymate/mymate/group/service/InvitationService.java
+++ b/src/main/java/com/mymate/mymate/group/service/InvitationService.java
@@ -2,170 +2,18 @@ package com.mymate.mymate.group.service;
 
 import com.mymate.mymate.group.dto.InvitationCreateRequest;
 import com.mymate.mymate.group.dto.InvitationResponse;
-import com.mymate.mymate.group.entity.Group;
-import com.mymate.mymate.group.entity.GroupMember;
-import com.mymate.mymate.group.entity.Invitation;
-import com.mymate.mymate.group.repository.GroupMemberRepository;
-import com.mymate.mymate.group.repository.GroupRepository;
-import com.mymate.mymate.group.repository.InvitationRepository;
-import com.mymate.mymate.member.Member;
-import com.mymate.mymate.member.repository.MemberRepository;
-import com.mymate.mymate.common.exception.general.GeneralException;
-import com.mymate.mymate.common.exception.general.status.ErrorStatus;
-import com.mymate.mymate.group.status.GroupErrorStatus;
-import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Service
-@RequiredArgsConstructor
-@Slf4j
-@Transactional(readOnly = true)
-public class InvitationService {
-
-    private final InvitationRepository invitationRepository;
-    private final GroupRepository groupRepository;
-    private final GroupMemberRepository groupMemberRepository;
-    private final MemberRepository memberRepository;
-    private final GroupService groupService;
-
-    private static final int INVITATION_EXPIRY_HOURS = 24; // 24시간 후 만료
-
-    @Transactional
-    public InvitationResponse createInvitation(InvitationCreateRequest request, Long groupId, Long inviterId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
-
-        // 소유자만 초대 가능
-        if (!group.getOwnerId().equals(inviterId)) {
-            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
-        }
-
-        // 초대받을 사용자 존재 확인
-        Member invitee = memberRepository.findById(request.getInviteeId())
-                .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
-
-        // 이미 그룹에 속한 멤버인지 확인
-        if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, request.getInviteeId())) {
-            throw new GeneralException(GroupErrorStatus.MEMBER_ALREADY_IN_GROUP);
-        }
-
-        // 이미 대기 중인 초대가 있는지 확인
-        if (invitationRepository.existsByGroupIdAndInviteeIdAndStatus(
-                groupId, request.getInviteeId(), Invitation.InvitationStatus.PENDING)) {
-            throw new GeneralException(GroupErrorStatus.INVITATION_ALREADY_EXISTS);
-        }
-
-        // 초대 생성
-        Invitation invitation = Invitation.builder()
-                .groupId(groupId)
-                .inviterId(inviterId)
-                .inviteeId(request.getInviteeId())
-                .expiresAt(LocalDateTime.now().plusHours(INVITATION_EXPIRY_HOURS))
-                .build();
-
-        Invitation savedInvitation = invitationRepository.save(invitation);
-
-        // 초대자 이름 조회
-        Member inviter = memberRepository.findById(inviterId)
-                .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
-
-        log.info("초대 생성 완료: invitationId={}, groupId={}, inviterId={}, inviteeId={}", 
-                savedInvitation.getId(), groupId, inviterId, request.getInviteeId());
-
-        return new InvitationResponse(savedInvitation, group.getName(), inviter.getUsername());
-    }
-
-    public List<InvitationResponse> getMyInvitations(Long memberId) {
-        List<Invitation> invitations = invitationRepository.findPendingInvitationsByInviteeId(memberId);
-        
-        return invitations.stream()
-                .map(invitation -> {
-                    Group group = groupRepository.findById(invitation.getGroupId())
-                            .orElseThrow(() -> new GeneralException(GroupErrorStatus.GROUP_NOT_FOUND));
-                    
-                    Member inviter = memberRepository.findById(invitation.getInviterId())
-                            .orElseThrow(() -> new GeneralException(MemberErrorStatus.MEMBER_NOT_FOUND));
-                    
-                    return new InvitationResponse(invitation, group.getName(), inviter.getUsername());
-                })
-                .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void acceptInvitation(Long invitationId, Long memberId) {
-        Invitation invitation = invitationRepository.findById(invitationId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.INVITATION_NOT_FOUND));
-
-        // 초대받은 사용자만 수락 가능
-        if (!invitation.getInviteeId().equals(memberId)) {
-            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
-        }
-
-        // 이미 처리된 초대인지 확인
-        if (!invitation.isPending()) {
-            throw new GeneralException(GroupErrorStatus.INVITATION_ALREADY_PROCESSED);
-        }
-
-        // 만료된 초대인지 확인
-        if (invitation.isExpired()) {
-            invitation.expire();
-            invitationRepository.save(invitation);
-            throw new GeneralException(GroupErrorStatus.INVITATION_EXPIRED);
-        }
-
-        // 그룹에 멤버 추가 (단일 그룹 정책으로 기존 그룹에서 자동 탈퇴)
-        groupService.addMember(invitation.getGroupId(), memberId, invitation.getInviterId());
-
-        // 초대 상태를 수락으로 변경
-        invitation.accept();
-        invitationRepository.save(invitation);
-
-        log.info("초대 수락 완료: invitationId={}, groupId={}, memberId={}", 
-                invitationId, invitation.getGroupId(), memberId);
-    }
-
-    @Transactional
-    public void cancelInvitation(Long invitationId, Long memberId) {
-        Invitation invitation = invitationRepository.findById(invitationId)
-                .orElseThrow(() -> new GeneralException(GroupErrorStatus.INVITATION_NOT_FOUND));
-
-        // 초대받은 사용자 또는 초대한 사용자만 취소 가능
-        if (!invitation.getInviteeId().equals(memberId) && 
-            !invitation.getInviterId().equals(memberId)) {
-            throw new GeneralException(GroupErrorStatus.FORBIDDEN);
-        }
-
-        // 이미 처리된 초대인지 확인
-        if (!invitation.isPending()) {
-            throw new GeneralException(GroupErrorStatus.INVITATION_ALREADY_PROCESSED);
-        }
-
-        invitation.cancel();
-        invitationRepository.save(invitation);
-
-        log.info("초대 취소 완료: invitationId={}, memberId={}", invitationId, memberId);
-    }
-
-    @Scheduled(fixedRate = 3600000) // 1시간마다 실행
-    @Transactional
-    public void expireInvitations() {
-        List<Invitation> expiredInvitations = invitationRepository.findExpiredInvitations(LocalDateTime.now());
-        
-        for (Invitation invitation : expiredInvitations) {
-            invitation.expire();
-            invitationRepository.save(invitation);
-        }
-
-        if (!expiredInvitations.isEmpty()) {
-            log.info("만료된 초대 처리 완료: count={}", expiredInvitations.size());
-        }
-    }
+public interface InvitationService {
+    
+    InvitationResponse createInvitation(InvitationCreateRequest request, Long inviterId);
+    
+    List<InvitationResponse> getMyInvitations(Long memberId);
+    
+    void acceptInvitation(Long invitationId, Long memberId);
+    
+    void cancelInvitation(Long invitationId, Long memberId);
+    
+    void expireInvitations();
 }

--- a/src/main/java/com/mymate/mymate/group/service/InvitationServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/group/service/InvitationServiceImpl.java
@@ -1,0 +1,186 @@
+package com.mymate.mymate.group.service;
+
+import com.mymate.mymate.group.dto.InvitationCreateRequest;
+import com.mymate.mymate.group.dto.InvitationResponse;
+import com.mymate.mymate.group.entity.Group;
+import com.mymate.mymate.group.entity.GroupMember;
+import com.mymate.mymate.group.entity.Invitation;
+import com.mymate.mymate.group.repository.GroupMemberRepository;
+import com.mymate.mymate.group.repository.GroupRepository;
+import com.mymate.mymate.group.repository.InvitationRepository;
+import com.mymate.mymate.member.Member;
+import com.mymate.mymate.member.repository.MemberRepository;
+import com.mymate.mymate.common.exception.group.GroupHandler;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+import com.mymate.mymate.common.exception.member.MemberHandler;
+import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class InvitationServiceImpl implements InvitationService {
+
+    private final InvitationRepository invitationRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+    private final GroupService groupService;
+
+    private static final int INVITATION_EXPIRY_HOURS = 24; // 24시간 후 만료
+
+    @Override
+    @Transactional
+    public InvitationResponse createInvitation(InvitationCreateRequest request, Long inviterId) {
+        // 초대자의 그룹 조회 (사용자당 하나의 그룹만 가질 수 있음)
+        List<GroupMember> inviterMemberships = groupMemberRepository.findByMemberId(inviterId);
+        if (inviterMemberships.isEmpty()) {
+            throw new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND);
+        }
+        
+        Group group = groupRepository.findById(inviterMemberships.get(0).getGroupId())
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND));
+
+        // 소유자만 초대 가능
+        if (!group.getOwnerId().equals(inviterId)) {
+            throw new GroupHandler(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 초대받을 사용자 존재 확인 (userId 또는 email로 검색)
+        Member invitee = memberRepository.findFirstByUserId(request.getInviteeIdentifier())
+                .or(() -> memberRepository.findByEmail(request.getInviteeIdentifier()))
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        // 이미 그룹에 속한 멤버인지 확인
+        if (groupMemberRepository.existsByGroupIdAndMemberId(group.getId(), invitee.getId())) {
+            throw new GroupHandler(GroupErrorStatus.MEMBER_ALREADY_IN_GROUP);
+        }
+
+        // 이미 대기 중인 초대가 있는지 확인
+        if (invitationRepository.existsByGroupIdAndInviteeIdAndStatus(
+                group.getId(), invitee.getId(), Invitation.InvitationStatus.PENDING)) {
+            throw new GroupHandler(GroupErrorStatus.INVITATION_ALREADY_EXISTS);
+        }
+
+        // 초대 생성
+        Invitation invitation = Invitation.builder()
+                .groupId(group.getId())
+                .inviterId(inviterId)
+                .inviteeId(invitee.getId())
+                .expiresAt(LocalDateTime.now().plusHours(INVITATION_EXPIRY_HOURS))
+                .build();
+
+        Invitation savedInvitation = invitationRepository.save(invitation);
+
+        // 초대자 이름 조회 (username이 null이면 email 사용)
+        Member inviter = memberRepository.findById(inviterId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        
+        String inviterDisplayName = inviter.getUsername() != null ? inviter.getUsername() : inviter.getEmail();
+
+        log.info("초대 생성 완료: invitationId={}, groupId={}, inviterId={}, inviteeId={}", 
+                savedInvitation.getId(), group.getId(), inviterId, invitee.getId());
+
+        return new InvitationResponse(savedInvitation, group.getName(), inviterDisplayName);
+    }
+
+    @Override
+    public List<InvitationResponse> getMyInvitations(Long memberId) {
+        List<Invitation> invitations = invitationRepository.findPendingInvitationsByInviteeId(memberId);
+        
+        return invitations.stream()
+                .map(invitation -> {
+                    Group group = groupRepository.findById(invitation.getGroupId())
+                            .orElseThrow(() -> new GroupHandler(GroupErrorStatus.GROUP_NOT_FOUND));
+                    
+                    Member inviter = memberRepository.findById(invitation.getInviterId())
+                            .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+                    
+                    String inviterDisplayName = inviter.getUsername() != null ? inviter.getUsername() : inviter.getEmail();
+                    return new InvitationResponse(invitation, group.getName(), inviterDisplayName);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void acceptInvitation(Long invitationId, Long memberId) {
+        Invitation invitation = invitationRepository.findById(invitationId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.INVITATION_NOT_FOUND));
+
+        // 초대받은 사용자만 수락 가능
+        if (!invitation.getInviteeId().equals(memberId)) {
+            throw new GroupHandler(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 이미 처리된 초대인지 확인
+        if (!invitation.isPending()) {
+            throw new GroupHandler(GroupErrorStatus.INVITATION_ALREADY_PROCESSED);
+        }
+
+        // 만료된 초대인지 확인
+        if (invitation.isExpired()) {
+            invitation.expire();
+            invitationRepository.save(invitation);
+            throw new GroupHandler(GroupErrorStatus.INVITATION_EXPIRED);
+        }
+
+        // 그룹에 멤버 추가 (단일 그룹 정책으로 기존 그룹에서 자동 탈퇴)
+        groupService.addMember(invitation.getGroupId(), memberId, invitation.getInviterId());
+
+        // 초대 상태를 수락으로 변경
+        invitation.accept();
+        invitationRepository.save(invitation);
+
+        log.info("초대 수락 완료: invitationId={}, groupId={}, memberId={}", 
+                invitationId, invitation.getGroupId(), memberId);
+    }
+
+    @Override
+    @Transactional
+    public void cancelInvitation(Long invitationId, Long memberId) {
+        Invitation invitation = invitationRepository.findById(invitationId)
+                .orElseThrow(() -> new GroupHandler(GroupErrorStatus.INVITATION_NOT_FOUND));
+
+        // 초대받은 사용자 또는 초대한 사용자만 취소 가능
+        if (!invitation.getInviteeId().equals(memberId) && 
+            !invitation.getInviterId().equals(memberId)) {
+            throw new GroupHandler(GroupErrorStatus.FORBIDDEN);
+        }
+
+        // 이미 처리된 초대인지 확인
+        if (!invitation.isPending()) {
+            throw new GroupHandler(GroupErrorStatus.INVITATION_ALREADY_PROCESSED);
+        }
+
+        invitation.cancel();
+        invitationRepository.save(invitation);
+
+        log.info("초대 취소 완료: invitationId={}, memberId={}", invitationId, memberId);
+    }
+
+    @Override
+    @Scheduled(fixedRate = 3600000) // 1시간마다 실행
+    @Transactional
+    public void expireInvitations() {
+        List<Invitation> expiredInvitations = invitationRepository.findExpiredInvitations(LocalDateTime.now());
+        
+        for (Invitation invitation : expiredInvitations) {
+            invitation.expire();
+            invitationRepository.save(invitation);
+        }
+
+        if (!expiredInvitations.isEmpty()) {
+            log.info("만료된 초대 처리 완료: count={}", expiredInvitations.size());
+        }
+    }
+}

--- a/src/main/java/com/mymate/mymate/group/status/GroupErrorStatus.java
+++ b/src/main/java/com/mymate/mymate/group/status/GroupErrorStatus.java
@@ -1,0 +1,57 @@
+package com.mymate.mymate.group.status;
+
+import com.mymate.mymate.common.exception.ExplainError;
+import com.mymate.mymate.common.exception.general.status.ErrorResponse;
+import org.springframework.http.HttpStatus;
+
+public enum GroupErrorStatus implements ErrorResponse {
+
+    // 그룹
+    @ExplainError("그룹을 찾을 수 없음")
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4001", "그룹을 찾을 수 없습니다."),
+    
+    @ExplainError("이미 그룹에 속한 멤버")
+    MEMBER_ALREADY_IN_GROUP(HttpStatus.CONFLICT, "GROUP4002", "이미 그룹에 속한 멤버입니다."),
+    
+    @ExplainError("그룹에 속하지 않은 멤버")
+    MEMBER_NOT_IN_GROUP(HttpStatus.BAD_REQUEST, "GROUP4003", "그룹에 속하지 않은 멤버입니다."),
+    
+    @ExplainError("그룹 소유자는 제거할 수 없음")
+    CANNOT_REMOVE_OWNER(HttpStatus.BAD_REQUEST, "GROUP4004", "그룹 소유자는 제거할 수 없습니다."),
+
+    // 초대
+    @ExplainError("초대를 찾을 수 없음")
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4010", "초대를 찾을 수 없습니다."),
+    
+    @ExplainError("이미 대기 중인 초대")
+    INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "GROUP4011", "이미 대기 중인 초대가 있습니다."),
+    
+    @ExplainError("이미 처리된 초대")
+    INVITATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "GROUP4012", "이미 처리된 초대입니다."),
+    
+    @ExplainError("만료된 초대")
+    INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "GROUP4013", "만료된 초대입니다."),
+
+    // 권한
+    @ExplainError("접근 권한이 없음")
+    FORBIDDEN(HttpStatus.FORBIDDEN, "GROUP4030", "접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    GroupErrorStatus(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getErrorStatus() { return httpStatus; }
+
+    @Override
+    public String getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/src/main/java/com/mymate/mymate/member/MemberDataInitializer.java
+++ b/src/main/java/com/mymate/mymate/member/MemberDataInitializer.java
@@ -2,12 +2,15 @@ package com.mymate.mymate.member;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import com.mymate.mymate.auth.enums.AuthProvider;
 import com.mymate.mymate.member.enums.Role;
 import com.mymate.mymate.member.repository.MemberRepository;
+import com.mymate.mymate.group.service.GroupService;
+import com.mymate.mymate.group.dto.GroupCreateRequest;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,16 +18,21 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Profile("dev")
 @Component
+@Order(2) // TermDataInitializer(Order=1) 다음에 실행
 @RequiredArgsConstructor
 public class MemberDataInitializer implements CommandLineRunner {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final GroupService groupService;
 
     @Override
     public void run(String... args) {
         // 개발 환경용 관리자 계정 초기화
         initializeAdminAccount();
+        
+        // 더미 사용자 및 그룹 데이터 초기화
+        initializeDummyData();
     }
 
     private void initializeAdminAccount() {
@@ -54,5 +62,49 @@ public class MemberDataInitializer implements CommandLineRunner {
                     memberRepository.save(adminMember);
                     log.info("MEMBER:INIT:::admin account created - email: {}, userId: {}", adminEmail, adminUserId);
                 });
+    }
+
+    private void initializeDummyData() {
+        // 더미 사용자 데이터
+        String[][] dummyUsers = {
+            {"user1", "user1@test.com", "김철수", "user1pass"},
+            {"user2", "user2@test.com", "이영희", "user2pass"},
+            {"user3", "user3@test.com", "박민수", "user3pass"},
+            {"user4", "user4@test.com", "정수진", "user4pass"},
+            {"user5", "user5@test.com", "최지훈", "user5pass"}
+        };
+
+        for (String[] userData : dummyUsers) {
+            String userId = userData[0];
+            String email = userData[1];
+            String username = userData[2];
+            String password = userData[3];
+
+            memberRepository.findByProviderAndProviderUserId(AuthProvider.LOCAL, userId)
+                    .ifPresentOrElse(existing -> {
+                        log.info("MEMBER:INIT:::dummy user {} already exists - skipping creation", userId);
+                    }, () -> {
+                        // 더미 사용자 생성
+                        Member dummyMember = Member.builder()
+                                .provider(AuthProvider.LOCAL)
+                                .providerUserId(userId)
+                                .email(email)
+                                .userId(userId)
+                                .username(username)
+                                .passwordHash(passwordEncoder.encode(password))
+                                .isSignUpCompleted(true)
+                                .role(Role.USER)
+                                .inactive(null)
+                                .build();
+
+                        Member savedMember = memberRepository.save(dummyMember);
+
+                        // 기본 그룹 생성
+                        GroupCreateRequest groupCreateRequest = new GroupCreateRequest(username + "의 그룹");
+                        groupService.createGroup(groupCreateRequest, savedMember.getId());
+
+                        log.info("MEMBER:INIT:::dummy user created - email: {}, userId: {}", email, userId);
+                    });
+        }
     }
 }

--- a/src/main/java/com/mymate/mymate/member/dto/MemberSearchResponse.java
+++ b/src/main/java/com/mymate/mymate/member/dto/MemberSearchResponse.java
@@ -1,22 +1,21 @@
 package com.mymate.mymate.member.dto;
 
 import com.mymate.mymate.member.Member;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class MemberSearchResponse {
-
     private Long id;
+    private String userId;
     private String username;
-    private String name;
     private String email;
-
+    
     public MemberSearchResponse(Member member) {
         this.id = member.getId();
+        this.userId = member.getUserId();
         this.username = member.getUsername();
-        this.name = member.getUsername();
         this.email = member.getEmail();
     }
 }

--- a/src/main/java/com/mymate/mymate/member/dto/MemberSearchResponse.java
+++ b/src/main/java/com/mymate/mymate/member/dto/MemberSearchResponse.java
@@ -1,0 +1,22 @@
+package com.mymate.mymate.member.dto;
+
+import com.mymate.mymate.member.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberSearchResponse {
+
+    private Long id;
+    private String username;
+    private String name;
+    private String email;
+
+    public MemberSearchResponse(Member member) {
+        this.id = member.getId();
+        this.username = member.getUsername();
+        this.name = member.getName();
+        this.email = member.getEmail();
+    }
+}

--- a/src/main/java/com/mymate/mymate/member/dto/MemberSearchResponse.java
+++ b/src/main/java/com/mymate/mymate/member/dto/MemberSearchResponse.java
@@ -16,7 +16,7 @@ public class MemberSearchResponse {
     public MemberSearchResponse(Member member) {
         this.id = member.getId();
         this.username = member.getUsername();
-        this.name = member.getName();
+        this.name = member.getUsername();
         this.email = member.getEmail();
     }
 }

--- a/src/main/java/com/mymate/mymate/member/repository/MemberRepository.java
+++ b/src/main/java/com/mymate/mymate/member/repository/MemberRepository.java
@@ -19,7 +19,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findFirstByUserId(String userId);
     Optional<Member> findByProviderAndProviderUserId(AuthProvider provider, String providerUserId);
     
-    @Query("SELECT m FROM Member m WHERE (m.username LIKE %:query% OR m.name LIKE %:query%) AND m.signUpCompleted = true")
+    @Query("SELECT m FROM Member m WHERE m.username LIKE %:query% AND m.isSignUpCompleted = true")
     List<Member> findByUsernameOrNameContainingIgnoreCase(@Param("query") String query);
 }
 

--- a/src/main/java/com/mymate/mymate/member/repository/MemberRepository.java
+++ b/src/main/java/com/mymate/mymate/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.mymate.mymate.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.mymate.mymate.auth.enums.AuthProvider;
@@ -15,6 +18,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUserId(String userId);
     Optional<Member> findFirstByUserId(String userId);
     Optional<Member> findByProviderAndProviderUserId(AuthProvider provider, String providerUserId);
+    
+    @Query("SELECT m FROM Member m WHERE (m.username LIKE %:query% OR m.name LIKE %:query%) AND m.signUpCompleted = true")
+    List<Member> findByUsernameOrNameContainingIgnoreCase(@Param("query") String query);
 }
 
 

--- a/src/main/java/com/mymate/mymate/member/repository/MemberRepository.java
+++ b/src/main/java/com/mymate/mymate/member/repository/MemberRepository.java
@@ -19,7 +19,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findFirstByUserId(String userId);
     Optional<Member> findByProviderAndProviderUserId(AuthProvider provider, String providerUserId);
     
-    @Query("SELECT m FROM Member m WHERE m.username LIKE %:query% AND m.isSignUpCompleted = true")
+    @Query("SELECT m FROM Member m WHERE (m.username LIKE %:query% OR m.email LIKE %:query% OR m.userId LIKE %:query%) AND m.isSignUpCompleted = true")
     List<Member> findByUsernameOrNameContainingIgnoreCase(@Param("query") String query);
 }
 

--- a/src/main/java/com/mymate/mymate/member/service/MemberService.java
+++ b/src/main/java/com/mymate/mymate/member/service/MemberService.java
@@ -1,9 +1,13 @@
 package com.mymate.mymate.member.service;
 
+import com.mymate.mymate.member.dto.MemberSearchResponse;
 import com.mymate.mymate.member.dto.ProfileSummaryResponse;
 import com.mymate.mymate.member.dto.ProfileUpdateRequest;
+
+import java.util.List;
 
 public interface MemberService {
     ProfileSummaryResponse getMyProfile(Long memberId);
     ProfileSummaryResponse updateMyProfile(Long memberId, ProfileUpdateRequest request);
+    List<MemberSearchResponse> searchMembers(String query);
 }

--- a/src/main/java/com/mymate/mymate/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/member/service/MemberServiceImpl.java
@@ -11,6 +11,9 @@ import com.mymate.mymate.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.mymate.mymate.member.repository.MemberRepository;
+import java.util.Objects;
+
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,10 +48,6 @@ public class MemberServiceImpl implements MemberService {
     public ProfileSummaryResponse updateMyProfile(Long memberId, ProfileUpdateRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException(MemberErrorStatus.MEMBER_NOT_FOUND.getMessage()));
-
-// at the top of the file
-import com.mymate.mymate.member.repository.MemberRepository;
-import java.util.Objects;
 
         MemberProfile profile = memberProfileRepository.findByMemberId(member.getId())
                 .orElseGet(() -> MemberProfile.builder().memberId(member.getId()).build());

--- a/src/main/java/com/mymate/mymate/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.mymate.mymate.member.service;
 import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
 import com.mymate.mymate.member.Member;
 import com.mymate.mymate.member.association.MemberProfile;
+import com.mymate.mymate.member.dto.MemberSearchResponse;
 import com.mymate.mymate.member.dto.ProfileSummaryResponse;
 import com.mymate.mymate.member.dto.ProfileUpdateRequest;
 import com.mymate.mymate.member.repository.MemberProfileRepository;
@@ -10,6 +11,9 @@ import com.mymate.mymate.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -75,5 +79,14 @@ import java.util.Objects;
                 .bio(profile.getBio())
                 .signUpCompleted(member.isSignUpCompleted())
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberSearchResponse> searchMembers(String query) {
+        List<Member> members = memberRepository.findByUsernameOrNameContainingIgnoreCase(query);
+        return members.stream()
+                .map(MemberSearchResponse::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mymate/mymate/term/TermDataInitializer.java
+++ b/src/main/java/com/mymate/mymate/term/TermDataInitializer.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import com.mymate.mymate.term.entity.Term;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Profile("dev")
 @Component
+@Order(1) // 먼저 실행
 @RequiredArgsConstructor
 public class TermDataInitializer implements CommandLineRunner {
 

--- a/src/main/java/com/mymate/mymate/web/controller/group/GroupController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/group/GroupController.java
@@ -2,6 +2,7 @@ package com.mymate.mymate.web.controller.group;
 
 import com.mymate.mymate.group.dto.GroupCreateRequest;
 import com.mymate.mymate.group.dto.GroupResponse;
+import com.mymate.mymate.group.dto.GroupUpdateNameRequest;
 import com.mymate.mymate.group.service.GroupService;
 import com.mymate.mymate.common.exception.ApiResponse;
 import com.mymate.mymate.common.exception.group.status.GroupSuccessStatus;
@@ -35,7 +36,7 @@ public class GroupController {
     @PostMapping
     @Operation(
         summary = "그룹 생성", 
-        description = "새로운 그룹을 생성합니다. 사용자가 새로운 그룹을 만들고 그룹장이 될 때 사용합니다.",
+        description = "새로운 그룹을 생성합니다. 기본적으로 회원가입 시 자동으로 그룹이 생성되지만, 그룹을 탈퇴한 후 다시 새로운 그룹을 만들고 싶을 때 사용하는 API입니다.",
         tags = {"Group"}
     )
     @ApiErrorCodeExamples({
@@ -141,5 +142,28 @@ public class GroupController {
         
         groupService.removeMember(groupId, memberId, userPrincipal.getId());
         return ApiResponse.onSuccess(GroupSuccessStatus.GROUP_MEMBER_REMOVED);
+    }
+
+    @PutMapping("/{groupId}/name")
+    @Operation(
+        summary = "그룹 이름 변경", 
+        description = "그룹의 이름을 변경합니다. 그룹장만 그룹 이름을 변경할 수 있습니다.",
+        tags = {"Group"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"GROUP_NOT_FOUND", "FORBIDDEN"}
+        )
+    })
+    public ResponseEntity<GroupResponse> updateGroupName(
+            @Parameter(description = "그룹 ID", required = true)
+            @PathVariable Long groupId,
+            @Valid @RequestBody GroupUpdateNameRequest request,
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        
+        GroupResponse response = groupService.updateGroupName(groupId, request, userPrincipal.getId());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/mymate/mymate/web/controller/group/GroupController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/group/GroupController.java
@@ -1,10 +1,10 @@
-package com.mymate.mymate.group.controller;
+package com.mymate.mymate.web.controller.group;
 
 import com.mymate.mymate.group.dto.GroupCreateRequest;
 import com.mymate.mymate.group.dto.GroupResponse;
 import com.mymate.mymate.group.service.GroupService;
-import com.mymate.mymate.common.exception.general.status.SuccessResponse;
-import com.mymate.mymate.common.exception.general.status.SuccessStatus;
+import com.mymate.mymate.common.exception.ApiResponse;
+import com.mymate.mymate.common.exception.group.status.GroupSuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -46,33 +46,33 @@ public class GroupController {
 
     @PostMapping("/{groupId}/leave")
     @Operation(summary = "그룹 탈퇴", description = "현재 사용자가 그룹에서 탈퇴합니다.")
-    public ResponseEntity<SuccessResponse> leaveGroup(
+    public ResponseEntity<ApiResponse<Void>> leaveGroup(
             @PathVariable Long groupId,
             @AuthenticationPrincipal Long memberId) {
         
         groupService.leaveGroup(groupId, memberId);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "그룹에서 탈퇴했습니다."));
+        return ApiResponse.onSuccess(GroupSuccessStatus.GROUP_LEFT);
     }
 
     @PostMapping("/{groupId}/members")
     @Operation(summary = "그룹 멤버 직접 추가", description = "그룹에 멤버를 직접 추가합니다.")
-    public ResponseEntity<SuccessResponse> addMember(
+    public ResponseEntity<ApiResponse<Void>> addMember(
             @PathVariable Long groupId,
             @RequestParam Long memberId,
             @AuthenticationPrincipal Long requesterId) {
         
         groupService.addMember(groupId, memberId, requesterId);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "그룹에 멤버를 추가했습니다."));
+        return ApiResponse.onSuccess(GroupSuccessStatus.GROUP_MEMBER_ADDED);
     }
 
     @DeleteMapping("/{groupId}/members/{memberId}")
     @Operation(summary = "그룹 멤버 제거", description = "그룹에서 멤버를 제거합니다.")
-    public ResponseEntity<SuccessResponse> removeMember(
+    public ResponseEntity<ApiResponse<Void>> removeMember(
             @PathVariable Long groupId,
             @PathVariable Long memberId,
             @AuthenticationPrincipal Long requesterId) {
         
         groupService.removeMember(groupId, memberId, requesterId);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "그룹에서 멤버를 제거했습니다."));
+        return ApiResponse.onSuccess(GroupSuccessStatus.GROUP_MEMBER_REMOVED);
     }
 }

--- a/src/main/java/com/mymate/mymate/web/controller/group/GroupController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/group/GroupController.java
@@ -5,7 +5,13 @@ import com.mymate.mymate.group.dto.GroupResponse;
 import com.mymate.mymate.group.service.GroupService;
 import com.mymate.mymate.common.exception.ApiResponse;
 import com.mymate.mymate.common.exception.group.status.GroupSuccessStatus;
+import com.mymate.mymate.common.exception.ApiErrorCodeExample;
+import com.mymate.mymate.common.exception.ApiErrorCodeExamples;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+import com.mymate.mymate.auth.jwt.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,58 +27,119 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Group", description = "그룹 관리 API")
+@SecurityRequirement(name = "accessToken")
 public class GroupController {
 
     private final GroupService groupService;
 
     @PostMapping
-    @Operation(summary = "그룹 생성", description = "새로운 그룹을 생성합니다.")
+    @Operation(
+        summary = "그룹 생성", 
+        description = "새로운 그룹을 생성합니다. 사용자가 새로운 그룹을 만들고 그룹장이 될 때 사용합니다.",
+        tags = {"Group"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"GROUP_NOT_FOUND"}
+        )
+    })
     public ResponseEntity<GroupResponse> createGroup(
             @Valid @RequestBody GroupCreateRequest request,
-            @AuthenticationPrincipal Long memberId) {
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        GroupResponse response = groupService.createGroup(request, memberId);
+        GroupResponse response = groupService.createGroup(request, userPrincipal.getId());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/me")
-    @Operation(summary = "내 그룹 목록 조회", description = "현재 사용자가 속한 그룹 목록을 조회합니다.")
+    @Operation(
+        summary = "내 그룹 목록 조회", 
+        description = "현재 사용자가 속한 그룹 목록을 조회합니다. 사용자가 자신이 참여한 모든 그룹을 확인할 때 사용합니다.",
+        tags = {"Group"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"GROUP_NOT_FOUND"}
+        )
+    })
     public ResponseEntity<List<GroupResponse>> getMyGroups(
-            @AuthenticationPrincipal Long memberId) {
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        List<GroupResponse> response = groupService.getMyGroups(memberId);
+        List<GroupResponse> response = groupService.getMyGroups(userPrincipal.getId());
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/{groupId}/leave")
-    @Operation(summary = "그룹 탈퇴", description = "현재 사용자가 그룹에서 탈퇴합니다.")
+    @Operation(
+        summary = "그룹 탈퇴", 
+        description = "현재 사용자가 그룹에서 탈퇴합니다. 사용자가 더 이상 그룹에 참여하고 싶지 않을 때 사용합니다.",
+        tags = {"Group"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"GROUP_NOT_FOUND", "MEMBER_NOT_IN_GROUP"}
+        )
+    })
     public ResponseEntity<ApiResponse<Void>> leaveGroup(
+            @Parameter(description = "그룹 ID", required = true)
             @PathVariable Long groupId,
-            @AuthenticationPrincipal Long memberId) {
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        groupService.leaveGroup(groupId, memberId);
+        groupService.leaveGroup(groupId, userPrincipal.getId());
         return ApiResponse.onSuccess(GroupSuccessStatus.GROUP_LEFT);
     }
 
     @PostMapping("/{groupId}/members")
-    @Operation(summary = "그룹 멤버 직접 추가", description = "그룹에 멤버를 직접 추가합니다.")
+    @Operation(
+        summary = "그룹 멤버 직접 추가", 
+        description = "그룹에 멤버를 직접 추가합니다. 그룹장이나 관리자가 특정 사용자를 그룹에 바로 초대할 때 사용합니다.",
+        tags = {"Group"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"GROUP_NOT_FOUND", "MEMBER_ALREADY_IN_GROUP", "FORBIDDEN"}
+        )
+    })
     public ResponseEntity<ApiResponse<Void>> addMember(
+            @Parameter(description = "그룹 ID", required = true)
             @PathVariable Long groupId,
+            @Parameter(description = "추가할 멤버 ID", required = true)
             @RequestParam Long memberId,
-            @AuthenticationPrincipal Long requesterId) {
+            @Parameter(description = "요청자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        groupService.addMember(groupId, memberId, requesterId);
+        groupService.addMember(groupId, memberId, userPrincipal.getId());
         return ApiResponse.onSuccess(GroupSuccessStatus.GROUP_MEMBER_ADDED);
     }
 
     @DeleteMapping("/{groupId}/members/{memberId}")
-    @Operation(summary = "그룹 멤버 제거", description = "그룹에서 멤버를 제거합니다.")
+    @Operation(
+        summary = "그룹 멤버 제거", 
+        description = "그룹에서 멤버를 제거합니다. 그룹장이나 관리자가 특정 멤버를 그룹에서 강제로 제외할 때 사용합니다.",
+        tags = {"Group"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"GROUP_NOT_FOUND", "MEMBER_NOT_IN_GROUP", "FORBIDDEN", "CANNOT_REMOVE_OWNER"}
+        )
+    })
     public ResponseEntity<ApiResponse<Void>> removeMember(
+            @Parameter(description = "그룹 ID", required = true)
             @PathVariable Long groupId,
+            @Parameter(description = "제거할 멤버 ID", required = true)
             @PathVariable Long memberId,
-            @AuthenticationPrincipal Long requesterId) {
+            @Parameter(description = "요청자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        groupService.removeMember(groupId, memberId, requesterId);
+        groupService.removeMember(groupId, memberId, userPrincipal.getId());
         return ApiResponse.onSuccess(GroupSuccessStatus.GROUP_MEMBER_REMOVED);
     }
 }

--- a/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
@@ -5,7 +5,13 @@ import com.mymate.mymate.group.dto.InvitationResponse;
 import com.mymate.mymate.group.service.InvitationService;
 import com.mymate.mymate.common.exception.ApiResponse;
 import com.mymate.mymate.common.exception.group.status.GroupSuccessStatus;
+import com.mymate.mymate.common.exception.ApiErrorCodeExample;
+import com.mymate.mymate.common.exception.ApiErrorCodeExamples;
+import com.mymate.mymate.group.status.GroupErrorStatus;
+import com.mymate.mymate.auth.jwt.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,47 +27,95 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Invitation", description = "초대 관리 API")
+@SecurityRequirement(name = "accessToken")
 public class InvitationController {
 
     private final InvitationService invitationService;
 
     @PostMapping("/groups/{groupId}/invitations")
-    @Operation(summary = "그룹 초대 생성", description = "특정 그룹에 사용자를 초대합니다.")
+    @Operation(
+        summary = "그룹 초대 생성", 
+        description = "특정 그룹에 사용자를 초대합니다. 그룹장이나 관리자가 다른 사용자를 그룹에 초대할 때 사용합니다.",
+        tags = {"Invitation"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"GROUP_NOT_FOUND", "INVITATION_ALREADY_EXISTS", "FORBIDDEN", "MEMBER_ALREADY_IN_GROUP"}
+        )
+    })
     public ResponseEntity<InvitationResponse> createInvitation(
+            @Parameter(description = "그룹 ID", required = true)
             @PathVariable Long groupId,
             @Valid @RequestBody InvitationCreateRequest request,
-            @AuthenticationPrincipal Long inviterId) {
+            @Parameter(description = "초대자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        InvitationResponse response = invitationService.createInvitation(request, groupId, inviterId);
+        InvitationResponse response = invitationService.createInvitation(request, groupId, userPrincipal.getId());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/me")
-    @Operation(summary = "내 초대 목록 조회", description = "현재 사용자에게 온 초대 목록을 조회합니다.")
+    @Operation(
+        summary = "내 초대 목록 조회", 
+        description = "현재 사용자에게 온 초대 목록을 조회합니다. 사용자가 자신에게 온 그룹 초대를 확인할 때 사용합니다.",
+        tags = {"Invitation"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"INVITATION_NOT_FOUND"}
+        )
+    })
     public ResponseEntity<List<InvitationResponse>> getMyInvitations(
-            @AuthenticationPrincipal Long memberId) {
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        List<InvitationResponse> response = invitationService.getMyInvitations(memberId);
+        List<InvitationResponse> response = invitationService.getMyInvitations(userPrincipal.getId());
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/{invitationId}/accept")
-    @Operation(summary = "초대 수락", description = "받은 초대를 수락합니다.")
+    @Operation(
+        summary = "초대 수락", 
+        description = "받은 초대를 수락합니다. 사용자가 그룹 초대를 받아서 그룹에 참여하고 싶을 때 사용합니다.",
+        tags = {"Invitation"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"INVITATION_NOT_FOUND", "INVITATION_EXPIRED", "INVITATION_ALREADY_PROCESSED"}
+        )
+    })
     public ResponseEntity<ApiResponse<Void>> acceptInvitation(
+            @Parameter(description = "초대 ID", required = true)
             @PathVariable Long invitationId,
-            @AuthenticationPrincipal Long memberId) {
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        invitationService.acceptInvitation(invitationId, memberId);
+        invitationService.acceptInvitation(invitationId, userPrincipal.getId());
         return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_ACCEPTED);
     }
 
     @PostMapping("/{invitationId}/cancel")
-    @Operation(summary = "초대 취소", description = "초대를 취소합니다.")
+    @Operation(
+        summary = "초대 취소", 
+        description = "초대를 취소합니다. 초대자가 보낸 초대를 취소하거나, 초대받은 사용자가 초대를 거절할 때 사용합니다.",
+        tags = {"Invitation"}
+    )
+    @ApiErrorCodeExamples({
+        @ApiErrorCodeExample(
+            value = GroupErrorStatus.class,
+            codes = {"INVITATION_NOT_FOUND", "INVITATION_ALREADY_PROCESSED", "FORBIDDEN"}
+        )
+    })
     public ResponseEntity<ApiResponse<Void>> cancelInvitation(
+            @Parameter(description = "초대 ID", required = true)
             @PathVariable Long invitationId,
-            @AuthenticationPrincipal Long memberId) {
+            @Parameter(description = "인증된 사용자 ID", hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        invitationService.cancelInvitation(invitationId, memberId);
+        invitationService.cancelInvitation(invitationId, userPrincipal.getId());
         return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_CANCELLED);
     }
 }

--- a/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
@@ -32,10 +32,10 @@ public class InvitationController {
 
     private final InvitationService invitationService;
 
-    @PostMapping("/groups/{groupId}/invitations")
+    @PostMapping("/invitations")
     @Operation(
         summary = "그룹 초대 생성", 
-        description = "특정 그룹에 사용자를 초대합니다. 그룹장이나 관리자가 다른 사용자를 그룹에 초대할 때 사용합니다.",
+        description = "현재 사용자의 그룹에 다른 사용자를 초대합니다. 사용자당 하나의 그룹만 가질 수 있으므로 그룹 ID는 필요하지 않습니다. 사용자 ID 또는 이메일로 초대할 수 있습니다.",
         tags = {"Invitation"}
     )
     @ApiErrorCodeExamples({
@@ -44,15 +44,13 @@ public class InvitationController {
             codes = {"GROUP_NOT_FOUND", "INVITATION_ALREADY_EXISTS", "FORBIDDEN", "MEMBER_ALREADY_IN_GROUP"}
         )
     })
-    public ResponseEntity<InvitationResponse> createInvitation(
-            @Parameter(description = "그룹 ID", required = true)
-            @PathVariable Long groupId,
+    public ResponseEntity<ApiResponse<InvitationResponse>> createInvitation(
             @Valid @RequestBody InvitationCreateRequest request,
             @Parameter(description = "초대자 ID", hidden = true)
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        InvitationResponse response = invitationService.createInvitation(request, groupId, userPrincipal.getId());
-        return ResponseEntity.ok(response);
+        InvitationResponse response = invitationService.createInvitation(request, userPrincipal.getId());
+        return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_CREATED, response);
     }
 
     @GetMapping("/me")
@@ -67,12 +65,12 @@ public class InvitationController {
             codes = {"INVITATION_NOT_FOUND"}
         )
     })
-    public ResponseEntity<List<InvitationResponse>> getMyInvitations(
+    public ResponseEntity<ApiResponse<List<InvitationResponse>>> getMyInvitations(
             @Parameter(description = "인증된 사용자 ID", hidden = true)
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
         List<InvitationResponse> response = invitationService.getMyInvitations(userPrincipal.getId());
-        return ResponseEntity.ok(response);
+        return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_LIST_FETCHED, response);
     }
 
     @PostMapping("/{invitationId}/accept")

--- a/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
@@ -1,10 +1,10 @@
-package com.mymate.mymate.group.controller;
+package com.mymate.mymate.web.controller.group;
 
 import com.mymate.mymate.group.dto.InvitationCreateRequest;
 import com.mymate.mymate.group.dto.InvitationResponse;
 import com.mymate.mymate.group.service.InvitationService;
-import com.mymate.mymate.common.exception.general.status.SuccessResponse;
-import com.mymate.mymate.common.exception.general.status.SuccessStatus;
+import com.mymate.mymate.common.exception.ApiResponse;
+import com.mymate.mymate.common.exception.group.status.GroupSuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,21 +47,21 @@ public class InvitationController {
 
     @PostMapping("/{invitationId}/accept")
     @Operation(summary = "초대 수락", description = "받은 초대를 수락합니다.")
-    public ResponseEntity<SuccessResponse> acceptInvitation(
+    public ResponseEntity<ApiResponse<Void>> acceptInvitation(
             @PathVariable Long invitationId,
             @AuthenticationPrincipal Long memberId) {
         
         invitationService.acceptInvitation(invitationId, memberId);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "초대를 수락했습니다."));
+        return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_ACCEPTED);
     }
 
     @PostMapping("/{invitationId}/cancel")
     @Operation(summary = "초대 취소", description = "초대를 취소합니다.")
-    public ResponseEntity<SuccessResponse> cancelInvitation(
+    public ResponseEntity<ApiResponse<Void>> cancelInvitation(
             @PathVariable Long invitationId,
             @AuthenticationPrincipal Long memberId) {
         
         invitationService.cancelInvitation(invitationId, memberId);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessStatus.OK, "초대를 취소했습니다."));
+        return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_CANCELLED);
     }
 }

--- a/src/main/java/com/mymate/mymate/web/controller/member/MemberController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/member/MemberController.java
@@ -7,22 +7,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import com.mymate.mymate.member.dto.MemberSearchResponse;
 import com.mymate.mymate.member.dto.ProfileSummaryResponse;
 import com.mymate.mymate.member.dto.ProfileUpdateRequest;
 import com.mymate.mymate.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -30,6 +21,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/profile")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "accessToken")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/mymate/mymate/web/controller/member/MemberController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/member/MemberController.java
@@ -6,11 +6,7 @@ import com.mymate.mymate.common.exception.member.status.MemberSuccessStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/mymate/mymate/web/controller/member/MemberController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/member/MemberController.java
@@ -21,12 +21,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.mymate.mymate.member.dto.MemberSearchResponse;
 import com.mymate.mymate.member.dto.ProfileSummaryResponse;
 import com.mymate.mymate.member.dto.ProfileUpdateRequest;
 import com.mymate.mymate.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/profile")
@@ -51,6 +54,15 @@ public class MemberController {
             @RequestBody @Validated ProfileUpdateRequest request
     ) {
         ProfileSummaryResponse response = memberService.updateMyProfile(principal.getId(), request);
+        return ApiResponse.onSuccess(MemberSuccessStatus.MEMBER_INFO_FETCHED, response);
+    }
+
+    @Operation(summary = "멤버 검색", description = "사용자명 또는 이름으로 회원을 검색합니다.")
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<MemberSearchResponse>>> searchMembers(
+            @RequestParam String q
+    ) {
+        List<MemberSearchResponse> response = memberService.searchMembers(q);
         return ApiResponse.onSuccess(MemberSuccessStatus.MEMBER_INFO_FETCHED, response);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,6 +7,8 @@ spring:
   h2:
     console:
       enabled: true
+      settings:
+        web-allow-others: true
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,25 +4,18 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
-
   h2:
     console:
       enabled: true
   jpa:
     hibernate:
       ddl-auto: update
-  logging:
-    level:
-      root: DEBUG
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
 
-logging:
-  level:
-    com.planit: DEBUG
-    org.springframework.web: INFO
+
 
 jwt:
   secret: "your-super-secret-key-that-should-be-long-and-secure-for-development"

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,11 +1,11 @@
 oauth:
   google:
-    client-id: ${GOOGLE_CLIENT_ID}
-    playground-client-id: ${GOOGLE_PLAYGROUND_CLIENT_ID}
+    client-id: ${GOOGLE_CLIENT_ID:temp-google-client-id}
+    playground-client-id: ${GOOGLE_PLAYGROUND_CLIENT_ID:temp-playground-client-id}
     
   kakao:
-    client-id: ${KAKAO_REST_API_KEY}
+    client-id: ${KAKAO_REST_API_KEY:temp-kakao-key}
     
   naver:
-    client-id: ${NAVER_CLIENT_ID}
-    client-secret: ${NAVER_CLIENT_SECRET}
+    client-id: ${NAVER_CLIENT_ID:temp-naver-client-id}
+    client-secret: ${NAVER_CLIENT_SECRET:temp-naver-secret}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,17 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
+# 로그 설정
+logging:
+  level:
+    root: INFO
+    com.mymate: INFO
+    org.springframework.data.redis: WARN
+    org.springframework.web: WARN
+    org.hibernate: WARN
+    org.springframework.security: WARN
+    org.springframework.boot.autoconfigure: WARN
+
 
 
 # 공통 설정이 있다면 여기에

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
 
 # 로그 설정
 logging:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -43,6 +43,11 @@ token:
     ttl-seconds: 1209600
   hmac-secret: "test-hmac-secret"
 
+solapi:
+  api-key: "test-api-key"
+  api-secret: "test-api-secret"
+  default-from: "test-from"
+
 logging:
   level:
     com.mymate.mymate: DEBUG


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 초대 및 그룹 관련 기능 구현하였습니다.


### 스크린샷 (선택)

<img width="1860" height="437" alt="image" src="https://github.com/user-attachments/assets/33ab3cde-65e2-4cdf-a769-c303bce7c341" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 그룹 관리 API 추가: 생성, 내 그룹 조회, 탈퇴, 멤버 추가/삭제, 이름 변경
  - 초대 관리 API 추가: 초대 생성, 내 초대 조회, 수락, 취소
  - 회원 검색 API 추가(/profile/search)
  - 회원가입 시 기본 그룹 자동 생성

- 설정
  - 로컬 개발용 컨테이너 포트 노출(앱 8080, Redis 6379) 및 로컬 빌드로 전환
  - 개발 환경 설정 정리: H2 콘솔 접근 허용, Redis 호스트/포트 환경변수화
  - OAuth 클라이언트 설정에 기본값 추가

- 기타
  - 테스트 환경에 메시지 서비스 관련 설정 키 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->