### PR TITLE
[refactor] 계정 및 퍼즐 DTO에서 회원 로그인 ID를 사용하도록 업데이트

### DIFF
--- a/src/main/java/com/mymate/mymate/account/dto/AccountResponse.java
+++ b/src/main/java/com/mymate/mymate/account/dto/AccountResponse.java
@@ -29,11 +29,11 @@ import java.util.List;
   "receiveAmount": 100000,
   "status": "PENDING",
   "groupId": 1,
-  "createdBy": 123,
+  "createdByMemberId": "sw1234",
   "participants": [
     {
       "id": 1,
-      "memberId": 123,
+      "memberLoginId": "sw1234",
       "memberName": "홍길동",
       "paymentAmount": 30000,
       "isPaid": true
@@ -75,8 +75,8 @@ public class AccountResponse {
     @Schema(description = "그룹 ID", example = "1")
     private Long groupId;
 
-    @Schema(description = "생성자 ID", example = "123")
-    private Long createdBy;
+    @Schema(description = "생성자 로그인 아이디", example = "sw1234")
+    private String createdByMemberId;
 
     @Schema(description = "정산 참여자 목록")
     private List<ParticipantResponse> participants;
@@ -87,7 +87,7 @@ public class AccountResponse {
     @Schema(description = "수정일시", example = "2024-01-15T10:30:00")
     private LocalDateTime updatedAt;
 
-    public static AccountResponse from(Account account, List<ParticipantResponse> participants) {
+    public static AccountResponse from(Account account, List<ParticipantResponse> participants, String createdByMemberId) {
         return AccountResponse.builder()
                 .id(account.getId())
                 .title(account.getTitle())
@@ -99,7 +99,7 @@ public class AccountResponse {
                 .receiveAmount(account.getReceiveAmount())
                 .status(account.getStatus())
                 .groupId(account.getGroupId())
-                .createdBy(account.getCreatedBy())
+                .createdByMemberId(createdByMemberId)
                 .participants(participants)
                 .createdAt(account.getCreatedAt())
                 .updatedAt(account.getUpdatedAt())
@@ -115,8 +115,8 @@ public class AccountResponse {
         @Schema(description = "참여자 ID", example = "1")
         private Long id;
 
-        @Schema(description = "멤버 ID", example = "123")
-        private Long memberId;
+        @Schema(description = "멤버 로그인 아이디", example = "sw1234")
+        private String memberLoginId;
 
         @Schema(description = "멤버명", example = "홍길동")
         private String memberName;

--- a/src/main/java/com/mymate/mymate/account/service/AccountServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/account/service/AccountServiceImpl.java
@@ -431,24 +431,40 @@ public class AccountServiceImpl implements AccountService {
                 .map(AccountParticipant::getMemberId)
                 .collect(Collectors.toList());
 
-        // 멤버 정보 조회
-        Map<Long, String> memberNameMap = memberRepository.findAllById(memberIds).stream()
+        // 멤버 정보 조회 (참여자 + 생성자)
+        Set<Long> allMemberIds = new HashSet<>(memberIds);
+        allMemberIds.add(account.getCreatedBy());
+
+        Map<Long, Member> memberMap = memberRepository.findAllById(allMemberIds).stream()
+                .collect(Collectors.toMap(Member::getId, member -> member));
+
+        Map<Long, String> memberNameMap = memberMap.entrySet().stream()
                 .collect(Collectors.toMap(
-                        Member::getId,
-                        member -> member.getUsername() != null ? member.getUsername() : member.getEmail()
+                        Map.Entry::getKey,
+                        entry -> {
+                            Member member = entry.getValue();
+                            return member.getUsername() != null ? member.getUsername() : member.getEmail();
+                        }
                 ));
 
-        // ParticipantResponse 생성
+        // ParticipantResponse 생성 (로그인 아이디 포함)
         List<AccountResponse.ParticipantResponse> participantResponses = participants.stream()
-                .map(participant -> AccountResponse.ParticipantResponse.builder()
-                        .id(participant.getId())
-                        .memberId(participant.getMemberId())
-                        .memberName(memberNameMap.get(participant.getMemberId()))
-                        .paymentAmount(participant.getPaymentAmount())
-                        .isPaid(participant.getIsPaid())
-                        .build())
+                .map(participant -> {
+                    Member member = memberMap.get(participant.getMemberId());
+                    return AccountResponse.ParticipantResponse.builder()
+                            .id(participant.getId())
+                            .memberLoginId(member != null ? member.getUserId() : null)
+                            .memberName(memberNameMap.get(participant.getMemberId()))
+                            .paymentAmount(participant.getPaymentAmount())
+                            .isPaid(participant.getIsPaid())
+                            .build();
+                })
                 .collect(Collectors.toList());
 
-        return AccountResponse.from(account, participantResponses);
+        // 생성자의 로그인 아이디
+        Member createdByMember = memberMap.get(account.getCreatedBy());
+        String createdByMemberId = createdByMember != null ? createdByMember.getUserId() : null;
+
+        return AccountResponse.from(account, participantResponses, createdByMemberId);
     }
 }

--- a/src/main/java/com/mymate/mymate/group/dto/InvitationCreateRequest.java
+++ b/src/main/java/com/mymate/mymate/group/dto/InvitationCreateRequest.java
@@ -1,24 +1,30 @@
 package com.mymate.mymate.group.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @Schema(description = "그룹 초대 생성 요청", example = """
 {
-  "inviteeIdentifier": "SZZYDE770"
+  "inviteeIdentifiers": ["SZZYDE770", "user@gmail.com", "ABC123"]
 }
 """)
 public class InvitationCreateRequest {
 
-    @NotBlank(message = "초대받을 사용자 식별자는 필수입니다")
-    @Schema(description = "초대받을 사용자 식별자 (사용자 ID 또는 이메일)", example = "SZZYDE770", required = true)
-    private String inviteeIdentifier;  // 사용자 ID 또는 이메일 (예: "SZZYDE770" 또는 "user@gmail.com")
+    @NotEmpty(message = "초대받을 사용자 식별자 목록은 필수입니다")
+    @Schema(description = "초대받을 사용자 식별자 목록 (사용자 ID 또는 이메일)", example = "[\"SZZYDE770\", \"user@gmail.com\"]", required = true)
+    @JsonProperty("inviteeIdentifiers")
+    private List<String> inviteeIdentifiers;  // 사용자 ID 또는 이메일 목록
 
-    public InvitationCreateRequest(String inviteeIdentifier) {
-        this.inviteeIdentifier = inviteeIdentifier;
+    public InvitationCreateRequest(List<String> inviteeIdentifiers) {
+        this.inviteeIdentifiers = inviteeIdentifiers;
     }
 }

--- a/src/main/java/com/mymate/mymate/group/service/InvitationService.java
+++ b/src/main/java/com/mymate/mymate/group/service/InvitationService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface InvitationService {
     
-    InvitationResponse createInvitation(InvitationCreateRequest request, Long inviterId);
+    List<InvitationResponse> createInvitations(InvitationCreateRequest request, String inviterMemberLoginId);
     
     List<InvitationResponse> getMyInvitations(Long memberId);
     

--- a/src/main/java/com/mymate/mymate/group/service/InvitationServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/group/service/InvitationServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,7 +41,13 @@ public class InvitationServiceImpl implements InvitationService {
 
     @Override
     @Transactional
-    public InvitationResponse createInvitation(InvitationCreateRequest request, Long inviterId) {
+    public List<InvitationResponse> createInvitations(InvitationCreateRequest request, String inviterMemberLoginId) {
+        // memberLoginId로 초대자 Member 조회
+        Member inviter = memberRepository.findByUserId(inviterMemberLoginId)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        
+        Long inviterId = inviter.getId();
+        
         // 초대자의 그룹 조회 (사용자당 하나의 그룹만 가질 수 있음)
         List<GroupMember> inviterMemberships = groupMemberRepository.findByMemberId(inviterId);
         if (inviterMemberships.isEmpty()) {
@@ -55,42 +62,58 @@ public class InvitationServiceImpl implements InvitationService {
             throw new GroupHandler(GroupErrorStatus.FORBIDDEN);
         }
 
-        // 초대받을 사용자 존재 확인 (userId 또는 email로 검색)
-        Member invitee = memberRepository.findFirstByUserId(request.getInviteeIdentifier())
-                .or(() -> memberRepository.findByEmail(request.getInviteeIdentifier()))
-                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
-
-        // 이미 그룹에 속한 멤버인지 확인
-        if (groupMemberRepository.existsByGroupIdAndMemberId(group.getId(), invitee.getId())) {
-            throw new GroupHandler(GroupErrorStatus.MEMBER_ALREADY_IN_GROUP);
-        }
-
-        // 이미 대기 중인 초대가 있는지 확인
-        if (invitationRepository.existsByGroupIdAndInviteeIdAndStatus(
-                group.getId(), invitee.getId(), Invitation.InvitationStatus.PENDING)) {
-            throw new GroupHandler(GroupErrorStatus.INVITATION_ALREADY_EXISTS);
-        }
-
-        // 초대 생성
-        Invitation invitation = Invitation.builder()
-                .groupId(group.getId())
-                .inviterId(inviterId)
-                .inviteeId(invitee.getId())
-                .expiresAt(LocalDateTime.now().plusHours(INVITATION_EXPIRY_HOURS))
-                .build();
-
-        Invitation savedInvitation = invitationRepository.save(invitation);
-
         // 초대자 이름 조회 (username이 null이면 email 사용)
-        Member inviter = memberRepository.findById(inviterId)
-                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
-        
         String inviterDisplayName = inviter.getUsername() != null ? inviter.getUsername() : inviter.getEmail();
 
-        log.info("초대 생성 완료: invitationId={}, groupId={}, inviterId={}, inviteeId={}", 
-                savedInvitation.getId(), group.getId(), inviterId, invitee.getId());
+        List<InvitationResponse> responses = new ArrayList<>();
+        List<String> failedInvitations = new ArrayList<>();
 
-        return new InvitationResponse(savedInvitation, group.getName(), inviterDisplayName);
+        for (String inviteeIdentifier : request.getInviteeIdentifiers()) {
+            try {
+                // 초대받을 사용자 존재 확인 (userId 또는 email로 검색)
+                Member invitee = memberRepository.findFirstByUserId(inviteeIdentifier)
+                        .or(() -> memberRepository.findByEmail(inviteeIdentifier))
+                        .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+                // 이미 그룹에 속한 멤버인지 확인
+                if (groupMemberRepository.existsByGroupIdAndMemberId(group.getId(), invitee.getId())) {
+                    failedInvitations.add(inviteeIdentifier + " (이미 그룹에 속한 멤버)");
+                    continue;
+                }
+
+                // 이미 대기 중인 초대가 있는지 확인
+                if (invitationRepository.existsByGroupIdAndInviteeIdAndStatus(
+                        group.getId(), invitee.getId(), Invitation.InvitationStatus.PENDING)) {
+                    failedInvitations.add(inviteeIdentifier + " (이미 대기 중인 초대)");
+                    continue;
+                }
+
+                // 초대 생성
+                Invitation invitation = Invitation.builder()
+                        .groupId(group.getId())
+                        .inviterId(inviterId)
+                        .inviteeId(invitee.getId())
+                        .expiresAt(LocalDateTime.now().plusHours(INVITATION_EXPIRY_HOURS))
+                        .build();
+
+                Invitation savedInvitation = invitationRepository.save(invitation);
+                responses.add(new InvitationResponse(savedInvitation, group.getName(), inviterDisplayName));
+
+                log.info("초대 생성 완료: invitationId={}, groupId={}, inviterId={}, inviteeId={}", 
+                        savedInvitation.getId(), group.getId(), inviterId, invitee.getId());
+
+            } catch (Exception e) {
+                log.warn("초대 생성 실패: inviteeIdentifier={}, error={}", inviteeIdentifier, e.getMessage());
+                failedInvitations.add(inviteeIdentifier + " (사용자를 찾을 수 없음)");
+            }
+        }
+
+        if (!failedInvitations.isEmpty()) {
+            log.warn("일부 초대 생성 실패: {}", String.join(", ", failedInvitations));
+        }
+
+        log.info("초대 생성 완료: 성공={}, 실패={}", responses.size(), failedInvitations.size());
+        return responses;
     }
 
     @Override

--- a/src/main/java/com/mymate/mymate/member/dto/ProfileSummaryResponse.java
+++ b/src/main/java/com/mymate/mymate/member/dto/ProfileSummaryResponse.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(description = "프로필 요약 응답", example = """
 {
-  "memberId": 123,
+  "id": 123,
+  "memberLoginId": "sw1234",
   "username": "홍길동",
   "email": "user@example.com",
   "nickname": "길동이",
@@ -23,8 +24,11 @@ import lombok.NoArgsConstructor;
 """)
 public class ProfileSummaryResponse {
 
-    @Schema(description = "멤버 ID", example = "123")
-    private Long memberId;
+    @Schema(description = "ID", example = "123")
+    private Long id;
+
+    @Schema(description = "로그인 아이디", example = "sw1234")
+    private String memberLoginId;
     
     @Schema(description = "사용자명", example = "홍길동")
     private String username;

--- a/src/main/java/com/mymate/mymate/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/member/service/MemberServiceImpl.java
@@ -33,7 +33,8 @@ public class MemberServiceImpl implements MemberService {
         MemberProfile profile = memberProfileRepository.findByMemberId(member.getId()).orElse(null);
 
         return ProfileSummaryResponse.builder()
-                .memberId(member.getId())
+                .id(member.getId())
+                .memberLoginId(member.getUserId())
                 .username(member.getUsername())
                 .email(member.getEmail())
                 .nickname(profile != null ? profile.getNickname() : null)
@@ -70,7 +71,8 @@ public class MemberServiceImpl implements MemberService {
         memberProfileRepository.save(profile);
 
         return ProfileSummaryResponse.builder()
-                .memberId(member.getId())
+                .id(member.getId())
+                .memberLoginId(member.getUserId())
                 .username(member.getUsername())
                 .email(member.getEmail())
                 .nickname(profile.getNickname())

--- a/src/main/java/com/mymate/mymate/puzzle/dto/PuzzleCreateRequest.java
+++ b/src/main/java/com/mymate/mymate/puzzle/dto/PuzzleCreateRequest.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
   "title": "운동하기",
   "description": "매일 30분 운동하기",
   "scheduledDate": "2024-01-15",
+  "memberLoginId": "sw1234",
   "recurrenceType": "DAILY",
   "recurrenceEndDate": "2024-01-31",
   "priority": "HIGH",
@@ -39,6 +40,9 @@ public class PuzzleCreateRequest {
 
     @NotNull(message = "예정일은 필수입니다")
     private LocalDate scheduledDate;
+
+    @Schema(description = "생성자 로그인 아이디", example = "sw1234")
+    private String memberLoginId;
 
     @Builder.Default
     private RecurrenceType recurrenceType = RecurrenceType.NONE;

--- a/src/main/java/com/mymate/mymate/puzzle/dto/PuzzleListResponse.java
+++ b/src/main/java/com/mymate/mymate/puzzle/dto/PuzzleListResponse.java
@@ -23,7 +23,7 @@ import java.util.List;
       "scheduledDate": "2024-01-15",
       "completedAt": null,
       "status": "PENDING",
-      "memberId": 123,
+      "memberLoginId": "sw1234",
       "recurrenceType": "DAILY",
       "recurrenceEndDate": "2024-01-31",
       "parentPuzzleId": null,
@@ -68,6 +68,24 @@ public class PuzzleListResponse {
                                         int currentPage, int size, boolean first, boolean last) {
         List<PuzzleResponse> puzzleResponses = puzzles.stream()
                 .map(PuzzleResponse::from)
+                .toList();
+        
+        return PuzzleListResponse.builder()
+                .puzzles(puzzleResponses)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .currentPage(currentPage)
+                .size(size)
+                .first(first)
+                .last(last)
+                .build();
+    }
+
+    public static PuzzleListResponse from(List<Puzzle> puzzles, long totalElements, int totalPages, 
+                                        int currentPage, int size, boolean first, boolean last, 
+                                        java.util.Map<Long, String> memberLoginIdMap) {
+        List<PuzzleResponse> puzzleResponses = puzzles.stream()
+                .map(puzzle -> PuzzleResponse.from(puzzle, memberLoginIdMap.get(puzzle.getMemberId())))
                 .toList();
         
         return PuzzleListResponse.builder()

--- a/src/main/java/com/mymate/mymate/puzzle/dto/PuzzleResponse.java
+++ b/src/main/java/com/mymate/mymate/puzzle/dto/PuzzleResponse.java
@@ -25,7 +25,7 @@ import java.time.LocalDateTime;
   "scheduledDate": "2024-01-15",
   "completedAt": null,
   "status": "PENDING",
-  "memberId": 123,
+  "memberLoginId": "sw1234",
   "recurrenceType": "DAILY",
   "recurrenceEndDate": "2024-01-31",
   "parentPuzzleId": null,
@@ -55,8 +55,8 @@ public class PuzzleResponse {
     @Schema(description = "상태", example = "PENDING")
     private PuzzleStatus status;
     
-    @Schema(description = "멤버 ID", example = "123")
-    private Long memberId;
+    @Schema(description = "멤버 로그인 아이디", example = "sw1234")
+    private String memberLoginId;
     
     @Schema(description = "반복 타입", example = "DAILY")
     private RecurrenceType recurrenceType;
@@ -87,7 +87,25 @@ public class PuzzleResponse {
                 .scheduledDate(puzzle.getScheduledDate())
                 .completedAt(puzzle.getCompletedAt())
                 .status(puzzle.getStatus())
-                .memberId(puzzle.getMemberId())
+                .recurrenceType(puzzle.getRecurrenceType())
+                .recurrenceEndDate(puzzle.getRecurrenceEndDate())
+                .parentPuzzleId(puzzle.getParentPuzzleId())
+                .priority(puzzle.getPriority())
+                .category(puzzle.getCategory())
+                .createdAt(puzzle.getCreatedAt())
+                .updatedAt(puzzle.getUpdatedAt())
+                .build();
+    }
+
+    public static PuzzleResponse from(Puzzle puzzle, String memberLoginId) {
+        return PuzzleResponse.builder()
+                .id(puzzle.getId())
+                .title(puzzle.getTitle())
+                .description(puzzle.getDescription())
+                .scheduledDate(puzzle.getScheduledDate())
+                .completedAt(puzzle.getCompletedAt())
+                .status(puzzle.getStatus())
+                .memberLoginId(memberLoginId)
                 .recurrenceType(puzzle.getRecurrenceType())
                 .recurrenceEndDate(puzzle.getRecurrenceEndDate())
                 .parentPuzzleId(puzzle.getParentPuzzleId())

--- a/src/main/java/com/mymate/mymate/puzzle/service/PuzzleServiceImpl.java
+++ b/src/main/java/com/mymate/mymate/puzzle/service/PuzzleServiceImpl.java
@@ -14,6 +14,8 @@ import com.mymate.mymate.puzzle.repository.PuzzleRepositoryCustom;
 import com.mymate.mymate.group.repository.GroupMemberRepository;
 import com.mymate.mymate.group.entity.GroupMember;
 import com.mymate.mymate.common.exception.puzzle.status.PuzzleErrorStatus;
+import com.mymate.mymate.member.Member;
+import com.mymate.mymate.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -33,6 +35,7 @@ public class PuzzleServiceImpl implements PuzzleService {
     private final PuzzleRepository puzzleRepository;
     private final PuzzleRepositoryCustom puzzleRepositoryCustom;
     private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
@@ -60,7 +63,8 @@ public class PuzzleServiceImpl implements PuzzleService {
         log.info("[PuzzleService] create done: puzzleId={}, memberId={}, groupId={}",
                 savedPuzzle.getId(), memberId, savedPuzzle.getGroupId());
         
-        return PuzzleResponse.from(savedPuzzle);
+        String memberLoginIdForCreate = getMemberLoginId(memberId);
+        return PuzzleResponse.from(savedPuzzle, memberLoginIdForCreate);
     }
 
     @Override
@@ -71,7 +75,8 @@ public class PuzzleServiceImpl implements PuzzleService {
         log.info("[PuzzleService] get done: puzzleId={}, memberId={}, groupId={}",
                 puzzleId, memberId, puzzle.getGroupId());
         
-        return PuzzleResponse.from(puzzle);
+        String memberLoginIdForGet = getMemberLoginId(memberId);
+        return PuzzleResponse.from(puzzle, memberLoginIdForGet);
     }
 
     @Override
@@ -85,6 +90,9 @@ public class PuzzleServiceImpl implements PuzzleService {
                 ? puzzleRepository.findByGroupId(groupId, pageable)
                 : puzzleRepository.findByMemberId(memberId, pageable);
         
+        // 퍼즐 작성자들의 memberLoginId 조회
+        java.util.Map<Long, String> memberLoginIdMap = getMemberLoginIdMap(puzzlePage.getContent());
+        
         return PuzzleListResponse.from(
                 puzzlePage.getContent(),
                 puzzlePage.getTotalElements(),
@@ -92,7 +100,8 @@ public class PuzzleServiceImpl implements PuzzleService {
                 puzzlePage.getNumber(),
                 puzzlePage.getSize(),
                 puzzlePage.isFirst(),
-                puzzlePage.isLast()
+                puzzlePage.isLast(),
+                memberLoginIdMap
         );
     }
 
@@ -123,7 +132,8 @@ public class PuzzleServiceImpl implements PuzzleService {
         Puzzle savedPuzzle = puzzleRepository.save(puzzle);
         log.info("[PuzzleService] update done: puzzleId={}, memberId={}", puzzleId, memberId);
         
-        return PuzzleResponse.from(savedPuzzle);
+        String memberLoginIdForUpdate = getMemberLoginId(memberId);
+        return PuzzleResponse.from(savedPuzzle, memberLoginIdForUpdate);
     }
 
     @Override
@@ -161,7 +171,8 @@ public class PuzzleServiceImpl implements PuzzleService {
         log.info("[PuzzleService] status update done: puzzleId={}, memberId={}, status={}",
                 puzzleId, memberId, request.getStatus());
         
-        return PuzzleResponse.from(savedPuzzle);
+        String memberLoginIdForStatus = getMemberLoginId(memberId);
+        return PuzzleResponse.from(savedPuzzle, memberLoginIdForStatus);
     }
 
     @Override
@@ -175,7 +186,7 @@ public class PuzzleServiceImpl implements PuzzleService {
                 ? puzzleRepository.findByGroupIdAndScheduledDate(groupId, date)
                 : puzzleRepository.findByMemberIdAndScheduledDate(memberId, date);
         return puzzles.stream()
-                .map(PuzzleResponse::from)
+                .map(p -> PuzzleResponse.from(p, getMemberLoginId(memberId)))
                 .toList();
     }
 
@@ -191,7 +202,7 @@ public class PuzzleServiceImpl implements PuzzleService {
                 ? puzzleRepository.findByGroupIdAndScheduledDateBetween(groupId, startDate, endDate)
                 : puzzleRepository.findByMemberIdAndScheduledDateBetween(memberId, startDate, endDate);
         return puzzles.stream()
-                .map(PuzzleResponse::from)
+                .map(p -> PuzzleResponse.from(p, getMemberLoginId(memberId)))
                 .toList();
     }
 
@@ -207,6 +218,9 @@ public class PuzzleServiceImpl implements PuzzleService {
                 ? puzzleRepository.findByGroupIdAndStatus(groupId, status, pageable)
                 : puzzleRepository.findByMemberIdAndStatus(memberId, status, pageable);
         
+        // 퍼즐 작성자들의 memberLoginId 조회
+        java.util.Map<Long, String> memberLoginIdMap = getMemberLoginIdMap(puzzlePage.getContent());
+        
         return PuzzleListResponse.from(
                 puzzlePage.getContent(),
                 puzzlePage.getTotalElements(),
@@ -214,7 +228,8 @@ public class PuzzleServiceImpl implements PuzzleService {
                 puzzlePage.getNumber(),
                 puzzlePage.getSize(),
                 puzzlePage.isFirst(),
-                puzzlePage.isLast()
+                puzzlePage.isLast(),
+                memberLoginIdMap
         );
     }
 
@@ -228,6 +243,9 @@ public class PuzzleServiceImpl implements PuzzleService {
                 memberId, groupId, category, pageable);
         Page<Puzzle> puzzlePage = puzzleRepository.findByMemberIdAndCategory(memberId, category, pageable);
         
+        // 퍼즐 작성자들의 memberLoginId 조회
+        java.util.Map<Long, String> memberLoginIdMap = getMemberLoginIdMap(puzzlePage.getContent());
+        
         return PuzzleListResponse.from(
                 puzzlePage.getContent(),
                 puzzlePage.getTotalElements(),
@@ -235,7 +253,8 @@ public class PuzzleServiceImpl implements PuzzleService {
                 puzzlePage.getNumber(),
                 puzzlePage.getSize(),
                 puzzlePage.isFirst(),
-                puzzlePage.isLast()
+                puzzlePage.isLast(),
+                memberLoginIdMap
         );
     }
 
@@ -248,6 +267,24 @@ public class PuzzleServiceImpl implements PuzzleService {
         return groupId;
     }
 
+    private String getMemberLoginId(Long memberId) {
+        return memberRepository.findById(memberId)
+                .map(Member::getUserId)
+                .orElse(null);
+    }
+
+    private java.util.Map<Long, String> getMemberLoginIdMap(List<Puzzle> puzzles) {
+        java.util.Set<Long> memberIds = puzzles.stream()
+                .map(Puzzle::getMemberId)
+                .collect(java.util.stream.Collectors.toSet());
+        
+        return memberRepository.findAllById(memberIds).stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Member::getId,
+                        Member::getUserId
+                ));
+    }
+
     @Override
     public PuzzleListResponse searchPuzzles(Long memberId, String searchText, Pageable pageable) {
         Long groupId = getGroupId(memberId);
@@ -257,6 +294,9 @@ public class PuzzleServiceImpl implements PuzzleService {
         log.info("[PuzzleService] search start: memberId={}, groupId={}, q={}, pageable={}", memberId, groupId, searchText, pageable);
         Page<Puzzle> puzzlePage = puzzleRepositoryCustom.searchByText(memberId, searchText, pageable);
         
+        // 퍼즐 작성자들의 memberLoginId 조회
+        java.util.Map<Long, String> memberLoginIdMap = getMemberLoginIdMap(puzzlePage.getContent());
+        
         return PuzzleListResponse.from(
                 puzzlePage.getContent(),
                 puzzlePage.getTotalElements(),
@@ -264,7 +304,8 @@ public class PuzzleServiceImpl implements PuzzleService {
                 puzzlePage.getNumber(),
                 puzzlePage.getSize(),
                 puzzlePage.isFirst(),
-                puzzlePage.isLast()
+                puzzlePage.isLast(),
+                memberLoginIdMap
         );
     }
 

--- a/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
+++ b/src/main/java/com/mymate/mymate/web/controller/group/InvitationController.java
@@ -9,6 +9,10 @@ import com.mymate.mymate.common.exception.ApiErrorCodeExample;
 import com.mymate.mymate.common.exception.ApiErrorCodeExamples;
 import com.mymate.mymate.group.status.GroupErrorStatus;
 import com.mymate.mymate.auth.jwt.UserPrincipal;
+import com.mymate.mymate.member.Member;
+import com.mymate.mymate.member.repository.MemberRepository;
+import com.mymate.mymate.common.exception.member.MemberHandler;
+import com.mymate.mymate.common.exception.member.status.MemberErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -31,11 +35,12 @@ import java.util.List;
 public class InvitationController {
 
     private final InvitationService invitationService;
+    private final MemberRepository memberRepository;
 
     @PostMapping("/invitations")
     @Operation(
         summary = "그룹 초대 생성", 
-        description = "현재 사용자의 그룹에 다른 사용자를 초대합니다. 사용자당 하나의 그룹만 가질 수 있으므로 그룹 ID는 필요하지 않습니다. 사용자 ID 또는 이메일로 초대할 수 있습니다.",
+        description = "현재 사용자의 그룹에 여러 사용자를 동시에 초대합니다. 사용자당 하나의 그룹만 가질 수 있으므로 그룹 ID는 필요하지 않습니다. 사용자 ID 또는 이메일 목록으로 초대할 수 있습니다.",
         tags = {"Invitation"}
     )
     @ApiErrorCodeExamples({
@@ -44,13 +49,17 @@ public class InvitationController {
             codes = {"GROUP_NOT_FOUND", "INVITATION_ALREADY_EXISTS", "FORBIDDEN", "MEMBER_ALREADY_IN_GROUP"}
         )
     })
-    public ResponseEntity<ApiResponse<InvitationResponse>> createInvitation(
+    public ResponseEntity<ApiResponse<List<InvitationResponse>>> createInvitations(
             @Valid @RequestBody InvitationCreateRequest request,
             @Parameter(description = "초대자 ID", hidden = true)
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         
-        InvitationResponse response = invitationService.createInvitation(request, userPrincipal.getId());
-        return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_CREATED, response);
+        // UserPrincipal의 id로 Member를 조회하여 memberLoginId를 가져옴
+        Member inviter = memberRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        
+        List<InvitationResponse> responses = invitationService.createInvitations(request, inviter.getUserId());
+        return ApiResponse.onSuccess(GroupSuccessStatus.INVITATION_CREATED, responses);
     }
 
     @GetMapping("/me")


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- AccountResponse의 createdBy를 createdByMemberId로 변경.

- ParticipantResponse에서 memberId 대신 memberLoginId 사용.

- PuzzleCreateRequest, PuzzleResponse, PuzzleListResponse에 memberLoginId 포함.

- InvitationService와 InvitationController를 다중 초대 처리 및 응답 목록 반환하도록 리팩토링.

- ProfileSummaryResponse에 memberLoginId 포함하도록 수정 및 서비스 메서드 업데이트.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
